### PR TITLE
Task #3711 - jre of the properties file does not work under windows

### DIFF
--- a/README
+++ b/README
@@ -19,9 +19,6 @@ Mailing List:
 FAQ:
   http://icedtea.classpath.org/wiki/FrequentlyAskedQuestions
 
-Anonymous Mercurial checkout:
-  hg clone http://icedtea.classpath.org/hg/icedtea-web
-
 NetX
 ====
 

--- a/netx/net/sourceforge/jnlp/controlpanel/JVMPanel.java
+++ b/netx/net/sourceforge/jnlp/controlpanel/JVMPanel.java
@@ -54,6 +54,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
 import net.sourceforge.jnlp.config.DeploymentConfiguration;
+import net.sourceforge.jnlp.runtime.JNLPRuntime;
 import net.sourceforge.jnlp.runtime.Translator;
 import net.sourceforge.jnlp.util.logging.OutputController;
 import net.sourceforge.jnlp.util.StreamUtils;
@@ -234,7 +235,9 @@ public class JVMPanel extends NamedBorderPanel {
             validationResult += "<span color=\"red\">" + Translator.R("CPJVMnotDir") + "</span><br />";
             latestOne = JvmValidationResult.STATE.NOT_DIR;
         }
-        File javaFile = new File(cmd + File.separator + "bin" + File.separator + "java");
+        File javaFile = new File(cmd + File.separator + "bin" + 
+                                       File.separator + "java" + 
+                                       (JNLPRuntime.isWindows() ? ".exe" : ""));
         if (javaFile.isFile()) {
             validationResult += "<span color=\"green\">" + Translator.R("CPJVMjava") + "</span><br />";
         } else {

--- a/rust-launcher/src/property.rs
+++ b/rust-launcher/src/property.rs
@@ -85,7 +85,7 @@ fn check_file_for_property(file: File, key: &str) -> Option<String> {
                     None => {}
                     Some(kvv) => {
                         if kvv.key.eq(key) {
-                            return Some(escape_unicode(kvv.value));
+                            return Some(escape_unicode(kvv.value.replace(r"\:", ":")));
                         }
                     }
                 }

--- a/rust-launcher/src/property_from_files_resolver.rs
+++ b/rust-launcher/src/property_from_files_resolver.rs
@@ -131,7 +131,7 @@ fn try_key_from_properties_files(logger: &os_access::Os, array: &[Option<std::pa
                 let mut info2 = String::new();
                 write!(&mut info2, "itw-rust-debug: located {} in file {}", value, file.clone().expect("file should be already verified").display()).expect("unwrap failed");
                 logger.log(&info2);
-                if validator.validate(&value) {
+                if validator.validate(&value, logger) {
                     return Some(value);
                 } else {
                     //the only output out of verbose mode


### PR DESCRIPTION
- Check under windows against java.exe, instead of java, both in rust-launcher and in itweb-settings
- Unmasking the colon at properties in the rust launcher

https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3711