### PR TITLE
Packed resources are stored in cache with double file extension

### DIFF
--- a/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
@@ -357,9 +357,9 @@ public class ResourceDownloader implements Runnable {
             // return ".gz", so if we check gzip first, we would end up
             // treating a pack200 file as a jar file.
             if (packgz) {
-                downloadPackGzFile(connection, new URL(downloadFrom + ".pack.gz"), downloadTo);
+                downloadPackGzFile(connection, downloadFrom, downloadTo);
             } else if (gzip) {
-                downloadGZipFile(connection, new URL(downloadFrom + ".gz"), downloadTo);
+                downloadGZipFile(connection, downloadFrom, downloadTo);
             } else {
                 downloadFile(connection, downloadTo);
             }

--- a/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
@@ -357,9 +357,9 @@ public class ResourceDownloader implements Runnable {
             // return ".gz", so if we check gzip first, we would end up
             // treating a pack200 file as a jar file.
             if (packgz) {
-                downloadPackGzFile(resource, connection, new URL(downloadFrom + ".pack.gz"), downloadTo);
+                downloadPackGzFile(resource, connection, downloadFrom, downloadTo);
             } else if (gzip) {
-                downloadGZipFile(resource, connection, new URL(downloadFrom + ".gz"), downloadTo);
+                downloadGZipFile(resource, connection, downloadFrom, downloadTo);
             } else {
                 downloadFile(resource, connection, downloadTo);
             }


### PR DESCRIPTION
see: https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3714