### PR TITLE
Allow installer to be built on AdoptOpenJDK infra

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -512,7 +512,7 @@ $(WIN_INSTALLER_DIR)/itw-installer.json: clean-win-installer
 win-installer: win-only-image $(WIN_INSTALLER_DIR)/itw-installer.json
 	"$(JAVA)" -jar "$(WIXGEN_JAR)" "$(DESTDIR)$(prefix)" -c $(WIN_INSTALLER_DIR)/itw-installer.json -o $(WIN_INSTALLER_DIR)/itw-installer.wxs
 	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/candle.exe /nologo itw-installer.wxs
-	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/light.exe /nologo -ext WixUIExtension itw-installer.wixobj
+	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/light.exe /nologo -sval -ext WixUIExtension itw-installer.wixobj
 endif
 
 # note that this is called only from windows specific target (hidden otherwise)


### PR DESCRIPTION
Currently the IcedTea-Web Windows installer can only be
built using an Admin account. By disabling the verification
it can be built by any user.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>