### PR TITLE
Adjustments to the msi-installer:

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -507,6 +507,9 @@ $(WIN_INSTALLER_DIR)/itw-installer.json: clean-win-installer
 	mkdir $(WIN_INSTALLER_DIR)
 	sed \
 	-e "s|../win-installer|$(WIN_INSTALLER_SRC_DIR)|g" \
+	-e "s|[@]MAJOR_VERSION[@]|$(MAJOR_VERSION)|g" \
+	-e "s|[@]MINOR_VERSION[@]|$(MINOR_VERSION)|g" \
+	-e "s|[@]MICRO_VERSION[@]|$(MICRO_VERSION)|g" \
 	-e s/[@]PACKAGE_VERSION[@]/$(PACKAGE_VERSION)/g $(WIN_INSTALLER_SRC_DIR)/installer.json.in > $@
 
 win-installer: win-only-image $(WIN_INSTALLER_DIR)/itw-installer.json

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1073,9 +1073,9 @@ AC_DEFUN_ONCE([IT_SET_VERSION],
   AC_MSG_RESULT([${FULL_VERSION}])
   AC_SUBST([FULL_VERSION])
 
-  MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's/^\([[0-9]]\)[[.]].*$/\1/g'`
-  MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's/^[[^.]]*[[.]]\([[0-9]]\).*$/\1/g'`
-  MICRO_VERSION=`echo $PACKAGE_VERSION | sed 's/^[[^.]]*[[.]][[^.]]*[[.]]\([[0-9]]\).*$/\1/g'`
+  MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's/^\([[0-9]][[0-9]]*\)[[.]].*$/\1/g'`
+  MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's/^[[^.]]*[[.]]\([[0-9]][[0-9]]*\).*$/\1/g'`
+  MICRO_VERSION=`echo $PACKAGE_VERSION | sed 's/^[[^.]]*[[.]][[^.]]*[[.]]\([[0-9]][[0-9]]*\).*$/\1/g'`
   AC_SUBST([MAJOR_VERSION])
   AC_SUBST([MINOR_VERSION])
   AC_SUBST([MICRO_VERSION])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1072,6 +1072,13 @@ AC_DEFUN_ONCE([IT_SET_VERSION],
   FULL_VERSION="${PACKAGE_VERSION}${ICEDTEA_REV}${ICEDTEA_PKG}"
   AC_MSG_RESULT([${FULL_VERSION}])
   AC_SUBST([FULL_VERSION])
+
+  MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's/^\([[0-9]]\)[[.]].*$/\1/g'`
+  MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's/^[[^.]]*[[.]]\([[0-9]]\).*$/\1/g'`
+  MICRO_VERSION=`echo $PACKAGE_VERSION | sed 's/^[[^.]]*[[.]][[^.]]*[[.]]\([[0-9]]\).*$/\1/g'`
+  AC_SUBST([MAJOR_VERSION])
+  AC_SUBST([MINOR_VERSION])
+  AC_SUBST([MICRO_VERSION])
 ])
 
 dnl Allows you to configure (enable/disable/set path to) the browser

--- a/win-installer/installer.json.in
+++ b/win-installer/installer.json.in
@@ -1,8 +1,8 @@
 {
   "appName": "IcedTea-Web @PACKAGE_VERSION@",
   "versionMajor": "1",
-  "versionMinor": "7",
-  "versionMicro": "0",
+  "versionMinor": "8",
+  "versionMicro": "1",
   "versionPatch": "0",
   "vendor": "IcedTea-Web open-source project",
   "installDirName": "WebStart",
@@ -21,8 +21,24 @@
 
   "registryKeys": [
     {
-      "root": "HKCR",
-      "key": "jnlp",
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\.jnlp",
+      "values": [
+        {
+          "type": "string",
+          "name": "",
+          "value": "JNLPFile"
+        },
+        {
+          "type": "string",
+          "name": "Content Type",
+          "value": "application/x-java-jnlp-file"
+        }
+      ]
+    },
+    {
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\jnlp",
       "values": [
         {
           "type": "string",
@@ -37,13 +53,67 @@
       ]
     },
     {
-      "root": "HKCR",
-      "key": "jnlp\\shell\\open\\command",
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\jnlp\\shell\\open\\command",
       "values": [
         {
           "type": "string",
           "name": "",
-          "value": "\"[INSTALLDIR]bin\\javaws.bat\" \"%1\""
+          "value": "\"[INSTALLDIR]bin\\javaws.exe\" \"%1\""
+        }
+      ]
+    },
+    {
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\JNLPFile",
+      "values": [
+        {
+          "type": "string",
+          "name": "",
+          "value": "JNLP File"
+        },
+        {
+          "type": "integer",
+          "name": "EditFlags",
+          "value": "65536"
+        }
+      ]
+    },
+    {
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\JNLPFile\\shell\\open\\command",
+      "values": [
+        {
+          "type": "string",
+          "name": "",
+          "value": "\"[INSTALLDIR]bin\\javaws.exe\" \"%1\""
+        }
+      ]
+    },
+    {
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\jnlps",
+      "values": [
+        {
+          "type": "string",
+          "name": "",
+          "value": "URL:jnlp Protocol"
+        },
+        {
+          "type": "string",
+          "name": "URL Protocol",
+          "value": ""
+        }
+      ]
+    },
+    {
+      "root": "HKLM",
+      "key": "SOFTWARE\\Classes\\jnlps\\shell\\open\\command",
+      "values": [
+        {
+          "type": "string",
+          "name": "",
+          "value": "\"[INSTALLDIR]bin\\javaws.exe\" \"%1\""
         }
       ]
     }

--- a/win-installer/installer.json.in
+++ b/win-installer/installer.json.in
@@ -1,8 +1,8 @@
 {
   "appName": "IcedTea-Web @PACKAGE_VERSION@",
-  "versionMajor": "1",
-  "versionMinor": "8",
-  "versionMicro": "1",
+  "versionMajor": "@MAJOR_VERSION@",
+  "versionMinor": "@MINOR_VERSION@",
+  "versionMicro": "@MICRO_VERSION@",
   "versionPatch": "0",
   "vendor": "IcedTea-Web open-source project",
   "installDirName": "WebStart",


### PR DESCRIPTION
 - change from java.bat to java.exe
 - use HKLM\Software\Classes instead of HKCR, as entries are otherwise
   made in HKCU\Software\Classes and then not apply to all users
 - register jnlp-file and jnlps-protocol