### PR TITLE
UrlUtilsTest.testDecodeUrlAsFile() fails on Windows

### DIFF
--- a/core/src/test/java/net/sourceforge/jnlp/util/UrlUtilsTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/util/UrlUtilsTest.java
@@ -138,8 +138,8 @@ public class UrlUtilsTest {
             File testFile = new File(testPath);
             URL notEncodedUrl = testFile.toURI().toURL();
             URL encodedUrl = testFile.toURI().toURL();
-            assertEquals(testFile, UrlUtils.decodeUrlAsFile(notEncodedUrl));
-            assertEquals(testFile, UrlUtils.decodeUrlAsFile(encodedUrl));
+            assertEquals("Not encoded url as file", testFile.getAbsoluteFile(), UrlUtils.decodeUrlAsFile(notEncodedUrl));
+            assertEquals("Encoded url as file", testFile.getAbsoluteFile(), UrlUtils.decodeUrlAsFile(encodedUrl));
         }
     }
     


### PR DESCRIPTION
Hi,

The `UrlUtilsTest.testDecodeUrlAsFile()` test fails on Windows with the following error:

    Running net.sourceforge.jnlp.util.UrlUtilsTest
    Tests run: 24, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 0.479 sec <<< FAILURE!
    testDecodeUrlAsFile(net.sourceforge.jnlp.util.UrlUtilsTest)  Time elapsed: 0.023 sec  <<< FAILURE!
    java.lang.AssertionError: expected:<\simple> but was:<C:\simple>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:834)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:144)
            at net.sourceforge.jnlp.util.UrlUtilsTest.testDecodeUrlAsFile(UrlUtilsTest.java:141)

I suggest comparing the decoded URL with the absolute file expected instead.