### PR TITLE
TinyHttpdImplTest.urlToFilePathTest() fails on Windows

### DIFF
--- a/core/src/test/java/net/sourceforge/jnlp/TinyHttpdImplTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/TinyHttpdImplTest.java
@@ -63,12 +63,12 @@ public class TinyHttpdImplTest {
             String newUrl = TinyHttpdImpl.urlToFilePath(url);
 
             Assert.assertFalse("File path should not contain query string: " + newUrl, newUrl.contains("?"));
-            Assert.assertTrue("File path should be relative: " + newUrl, newUrl.startsWith("./"));
+            Assert.assertTrue("File path should be relative: " + newUrl, newUrl.startsWith("." + File.separator));
             Assert.assertFalse("File path should not contain \"/XslowX\":" + newUrl,
                     newUrl.toLowerCase().contains("/XslowX".toLowerCase()));
 
             if (url.endsWith("/")) {
-                Assert.assertTrue(newUrl.endsWith("/index.html"));
+                Assert.assertTrue(newUrl.endsWith(File.separator + "index.html"));
             }
         }
     }


### PR DESCRIPTION
Hi,

The `TinyHttpdImplTest.urlToFilePathTest()` test doesn't work on Windows because it checks unix style separators in the file paths. Here is a fix that will work everywhere.