### PR TITLE
PolicyFileModel fails to parse the locked policy files on Windows

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/policyeditor/PolicyFileModel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/policyeditor/PolicyFileModel.java
@@ -36,10 +36,15 @@ exception statement from your version.
 
 package net.adoptopenjdk.icedteaweb.client.policyeditor;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.channels.Channels;
 import java.nio.channels.FileLock;
 import java.util.Collection;
 import java.util.Collections;
@@ -110,7 +115,7 @@ public class PolicyFileModel {
         clearPermissions();
         final FileLock fileLock = FileUtils.getFileLock(file.getAbsolutePath(), false, true);
         try {
-            parser.read(new FileReader(file));
+            parser.read(new BufferedReader(new InputStreamReader(Channels.newInputStream(fileLock.channel()))));
             keystoreInfo = new KeystoreInfo(parser.getKeyStoreUrl(), parser.getKeyStoreType(), parser.getKeyStoreProvider(), parser.getStorePassURL());
             final Set<PolicyParser.GrantEntry> grantEntries = new HashSet<>(Collections.list(parser.grantElements()));
             synchronized (permissionsMap) {
@@ -183,7 +188,7 @@ public class PolicyFileModel {
                     parser.add(grantEntry);
                 }
             }
-            parser.write(new FileWriter(file));
+            parser.write(new BufferedWriter(new OutputStreamWriter(Channels.newOutputStream(fileLock.channel()))));
         } catch (final IOException e) {
             LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
         } finally {

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/policyeditor/PolicyFileModelTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/policyeditor/PolicyFileModelTest.java
@@ -112,6 +112,19 @@ public class PolicyFileModelTest {
     }
 
     @Test
+    public void testSavePolicyFile() throws Exception {
+        File file = new File(tempFilePath);
+        FileUtils.saveFile(EXAMPLE_POLICY_1, new File(tempFilePath));
+        assertEquals("policy file size", EXAMPLE_POLICY_1.length(), file.length());
+        
+        model.setFile(file);
+        model.openAndParsePolicyFile();
+        model.savePolicyFile();
+
+        assertTrue("policy file size isn't at least " + EXAMPLE_POLICY_1.length() + " bytes", file.length() >= EXAMPLE_POLICY_1.length());
+    }
+
+    @Test
     public void testHasChangedIsFalseInitially() throws Exception {
         assertFalse("Model should not report changes made initially", model.hasChanged());
     }


### PR DESCRIPTION
The `openAndParsePolicyFile()` method in `PolicyFileModel` acquires a FileLock on the policy file before parsing it. It doesn't seem to work on Windows with Java 8u191, several tests fail with the following error:

    java.io.IOException: The process cannot access the file because another process has locked a portion of the file
            at java.io.FileInputStream.readBytes(Native Method)
            at java.io.FileInputStream.read(FileInputStream.java:255)
            at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
            at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
            at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
            at java.io.InputStreamReader.read(InputStreamReader.java:184)
            at java.io.BufferedReader.fill(BufferedReader.java:161)
            at java.io.BufferedReader.read(BufferedReader.java:182)
            at java.io.StreamTokenizer.read(StreamTokenizer.java:500)
            at java.io.StreamTokenizer.nextToken(StreamTokenizer.java:544)
            at sun.security.provider.PolicyParser.read(PolicyParser.java:193)
            at net.adoptopenjdk.icedteaweb.client.policyeditor.PolicyFileModel.openAndParsePolicyFile(PolicyFileModel.java:113)

This can be either fixed by using a shared lock instead of an exclusive lock (but I'm not sure about the side effects), or by parsing from the channel associated to the lock instead of creating a separate FileReader.