### PR TITLE
Console buttons spacing

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/console/JavaConsole.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/console/JavaConsole.java
@@ -265,7 +265,7 @@ public class JavaConsole implements ObservableMessagesProvider {
         c.weighty = 0;
 
         JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new GridLayout(2, 0, 0, 0));
+        buttonPanel.setLayout(new GridLayout(2, 0, 10, 10));
         contentPanel.add(buttonPanel, c);
 
         JButton gcButton = new JButton(R("CONSOLErungc"));


### PR DESCRIPTION
There is no space between the console buttons:

![2019-04-19 00_40_34-Java Console](https://user-images.githubusercontent.com/54304/56396020-4e6ffd00-623d-11e9-98bb-365522ebee86.png)

This PR adds a 10px margin between them:

![2019-04-19 00_40_00-Java Console](https://user-images.githubusercontent.com/54304/56396038-66478100-623d-11e9-91d4-05dab5629309.png)

The layout of this window could be further improved (better alignment, margin consistency) but this is a first step. Is there any objection to use an advanced layout like [MigLayout](http://www.miglayout.com)? That would significantly simplify the code.