### PR TITLE
Missing tryLock() method in WindowsLockedFile

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/util/lockingfile/LockedFile.java
+++ b/core/src/main/java/net/sourceforge/jnlp/util/lockingfile/LockedFile.java
@@ -206,6 +206,15 @@ public class LockedFile {
             super.threadLock.lock();
         }
 
+        @Override
+        public boolean tryLock() throws IOException {
+            if (super.threadLock.tryLock()) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
         /*Comment why it is different*/
         @Override
         public void unlock() throws IOException {


### PR DESCRIPTION
WindowsLockedFile doesn't override the tryLock() method. This is causing test failures in CacheLRUWrapperTest on Windows (the same locked file error recently fixed in PolicyFile).