### PR TITLE
Launchers from pom

### DIFF
--- a/launchers/build.sh
+++ b/launchers/build.sh
@@ -39,7 +39,7 @@ function publishExternalLib() {
 if [ "x$ITW_LIBS" = "xDISTRIBUTION" ] ; then
   RESOURCES_SRC_TO_DEST["$1"]="$1"
 else
-   publishInternalLib "$1" "$LIB_TARGET_DIR"
+  publishInternalLib "$1" "$LIB_TARGET_DIR"
 fi
 }
 
@@ -94,24 +94,44 @@ function build() {
       fi
     popd
   elif [ "x$TYPE" = "xsh" ]; then
-    ls -l $SCRIPT_DIR/shell-launcher
+    for x in `find $SCRIPT_DIR/shell-launcher -type f ` ; do
+      nwname=`basename $x | sed "s/launchers/$PROGRAM_NAME/" | sed "s/.in//"`
+      cat $x | sed \
+        -e "s|[@]TAGSOUP_JAR[@]|$TAGSOUP_JAR|g" \
+        -e "s|[@]RHINO_JAR[@]|$RHINO_JAR|g" \
+        -e "s|[@]SLFAPI_JAR[@]|$SLFAPI_JAR|g" \
+        -e "s|[@]SLFSIMPLE_JAR[@]|$SLFSIMPLE_JAR|g" \
+        -e "s|[@]MSLINKS_JAR[@]|$MSLINKS_JAR|g" \
+        -e "s|[@]TAGSOUP_JAR[@]|$TAGSOUP_JAR|g" \
+        -e "s|[@]CORE_JAR[@]|$CORE_JAR|g" \
+        -e "s|[@]COMMON_JAR[@]|$COMMON_JAR|g" \
+        -e "s|[@]JNLPAPI_JAR[@]|$JNLPAPI_JAR|g" \
+        -e "s|[@]XMLPARSER_JAR[@]|$XMLPARSER_JAR|g" \
+        -e "s|[@]SPLASH_PNG[@]|$SPLASH_PNG|g" \
+        -e "s|[@]MODULARJDK_ARGS_LOCATION[@]|$MODULARJDK_ARGS_LOCATION|g" \
+        -e "s|[@]JRE[@]|$JRE|g" \
+        -e "s|[@]MAIN_CLASS[@]|$MAIN_CLASS|g" \
+        -e "s|[@]ITW_LIBS[@]|$ITW_LIBS|g" \
+      >  $BIN_TARGET_DIR/$nwname ;
+      chmod 755 $BIN_TARGET_DIR/$nwname
+    done
   else
     echo "invlaid build type: $TYPE"
     exit 2
   fi
 }
 
-mkdir $TARGET_TMP
-export ITW_TMP_REPLACEMENT=$TARGET_TMP
+build sh javaws         net.sourceforge.jnlp.runtime.Boot
+build sh itweb-settings net.sourceforge.jnlp.controlpanel.CommandLine
+build sh policyeditor   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
+
+mkdir $TARGET_TMP  # for tests output
+export ITW_TMP_REPLACEMENT=$TARGET_TMP # for tests output
 build rust javaws         net.sourceforge.jnlp.runtime.Boot
 build rust itweb-settings net.sourceforge.jnlp.controlpanel.CommandLine
 build rust policyeditor   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
 if [ ! "$KCOV" = "none" ] ; then 
   build rust coverage   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
 fi
-
-build sh javaws         net.sourceforge.jnlp.runtime.Boot
-build sh itweb-settings net.sourceforge.jnlp.controlpanel.CommandLine
-build sh policyeditor   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
 
 

--- a/launchers/build.sh
+++ b/launchers/build.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+declare -A RESOURCES_SRC_TO_DEST
+
+set -x
+set -e
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/configure.sh
+
+mkdir -p "$LIB_TARGET_DIR"
+mkdir -p "$ITW_TARGET_DIR"
+mkdir -p "$ETC_TARGET_DIR"
+mkdir -p "$BIN_TARGET_DIR"
+mkdir -p "$ICO_TARGET_DIR"
+mkdir -p "$SPLASH_TARGET_DIR"
+
+function getTarget() {
+ echo "$2/`basename \"$1\"`"
+}
+
+function publishInternalLib() {
+ cp $1 `getTarget $1 $2`
+ RESOURCES_SRC_TO_DEST["$1"]="`getTarget $1 $2`"
+}
+
+function publishExternalLib() {
+if [ "x$ITW_LIBS" = "xDISTRIBUTION" ] ; then
+  RESOURCES_SRC_TO_DEST["$1"]="$1"
+else
+   publishInternalLib "$1" "$LIB_TARGET_DIR"
+fi
+}
+
+publishExternalLib "$RHINO_SRC"
+publishExternalLib "$TAGSOUP_SRC"
+publishExternalLib "$SLFAPI_SRC"
+publishExternalLib "$SLFSIMPLE_SRC"
+publishExternalLib "$MSLINKS_SRC"
+publishInternalLib "$CORE_SRC" "$ITW_TARGET_DIR"
+publishInternalLib "$COMMON_SRC" "$ITW_TARGET_DIR"
+publishInternalLib "$JNLPAPI_SRC" "$ITW_TARGET_DIR"
+publishInternalLib "$XMLPARSER_SRC" "$ITW_TARGET_DIR"
+
+publishInternalLib "$SPLASH_PNG_SRC" "$SPLASH_TARGET_DIR"
+publishInternalLib "$JAVAWS_ICO_SRC" "$ICO_TARGET_DIR"
+publishInternalLib "$MODULARJDK_ARGS_FILE_SRC" "$ETC_TARGET_DIR"
+
+
+function build() {
+  TYPE=$1 # sh+bats x rust+rust-coverage
+  PROGRAM_NAME=$2 # only used to name the in file
+  export MAIN_CLASS=$3
+  export TAGSOUP_JAR=${RESOURCES_SRC_TO_DEST["$TAGSOUP_SRC"]}
+  export RHINO_JAR=${RESOURCES_SRC_TO_DEST["$RHINO_SRC"]}
+  export SLFAPI_JAR=${RESOURCES_SRC_TO_DEST["$SLFAPI_SRC"]}
+  export SLFSIMPLE_JAR=${RESOURCES_SRC_TO_DEST["$SLFSIMPLE_SRC"]}
+  export MSLINKS_JAR=${RESOURCES_SRC_TO_DEST["$MSLINKS_SRC"]}
+  export JRE
+  export ITW_LIBS
+  export CORE_JAR=${RESOURCES_SRC_TO_DEST["$CORE_SRC"]}
+  export COMMON_JAR=${RESOURCES_SRC_TO_DEST["$COMMON_SRC"]}
+  export JNLPAPI_JAR=${RESOURCES_SRC_TO_DEST["$JNLPAPI_SRC"]}
+  export XMLPARSER_JAR=${RESOURCES_SRC_TO_DEST["$XMLPARSER_SRC"]}
+  export SPLASH_PNG=${RESOURCES_SRC_TO_DEST["$SPLASH_PNG_SRC"]}
+  export MODULARJDK_ARGS_LOCATION=${RESOURCES_SRC_TO_DEST["$MODULARJDK_ARGS_FILE_SRC"]}
+  BUILD_DIR=$TARGET/launcher.in.$PROGRAM_NAME
+  if [ "x$TYPE" = "xrust" ]; then
+    cp -r $SCRIPT_DIR/rust-launcher $BUILD_DIR
+    pushd $BUILD_DIR
+      if [ "x$PROGRAM_NAME" == "xcoverage" ] ; then
+        cargo test  --no-run
+        rm -fv $BUILD_DIR/target/debug/launcher-*.d ;
+        $KCOV $BUILD_DIR $BUILD_DIR/target/debug/launcher-*
+      else
+        #on linux patch  out deps?
+        RUST_BACKTRACE=1 cargo test
+        #some windows?
+        #[target.x86_64-pc-windows-msvc]
+        #rustflags = ["-C", "target-feature=+crt-static"]
+        cargo build --release
+        cp -v $BUILD_DIR/target/release/launcher $BIN_TARGET_DIR/$PROGRAM_NAME ; \
+      fi
+    popd
+  elif [ "x$TYPE" = "xsh" ]; then
+    ls -l $SCRIPT_DIR/shell-launcher
+  else
+    echo "invlaid build type: $TYPE"
+    exit 2
+  fi
+}
+
+mkdir $TARGET_TMP
+export ITW_TMP_REPLACEMENT=$TARGET_TMP
+build rust javaws         net.sourceforge.jnlp.runtime.Boot
+build rust itweb-settings net.sourceforge.jnlp.controlpanel.CommandLine
+build rust policyeditor   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
+if [ ! "$KCOV" = "none" ] ; then 
+  build rust coverage   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
+fi
+
+build sh javaws         net.sourceforge.jnlp.runtime.Boot
+build sh itweb-settings net.sourceforge.jnlp.controlpanel.CommandLine
+build sh policyeditor   net.sourceforge.jnlp.security.policyeditor.PolicyEditor
+
+

--- a/launchers/configure.sh
+++ b/launchers/configure.sh
@@ -18,26 +18,26 @@ rm -rf "$TARGET"
 
 # where to search for libraris [MAVEN/SYSTEM]
 if [ "x$ITW_LIBS" = "x" ] ; then
-  ITW_LIBS="BUNDLED"
+  readonly ITW_LIBS="BUNDLED"
 else
   readonly ITW_LIBS=$ITW_LIBS
 fi
 
 # where to gather external libraries
 if [ "x$LIB_TARGET_DIR" == "x" ] ; then
-  readonly LIB_TARGET_DIR=$TARGET/lib
+  readonly LIB_TARGET_DIR=$TARGET/libs
 else
   readonly LIB_TARGET_DIR=$LIB_TARGET_DIR
 fi
 # where to gather itw's libraries
 if [ "x$ITW_TARGET_DIR" == "x" ] ; then
-  readonly ITW_TARGET_DIR=$TARGET/lib
+  readonly ITW_TARGET_DIR=$TARGET/libs
 else
   readonly ITW_TARGET_DIR=$ITW_TARGET_DIR
 fi
 # where to gather config files
 if [ "x$ETC_TARGET_DIR" == "x" ] ; then
-  readonly ETC_TARGET_DIR=$TARGET/lib
+  readonly ETC_TARGET_DIR=$TARGET/libs
 else
   readonly ETC_TARGET_DIR=$ETC_TARGET_DIR
 fi
@@ -49,13 +49,13 @@ else
 fi
 # where to splash
 if [ "x$SPLASH_TARGET_DIR" == "x" ] ; then
-  readonly SPLASH_TARGET_DIR=$TARGET/lib
+  readonly SPLASH_TARGET_DIR=$TARGET/libs
 else
   readonly SPLASH_TARGET_DIR=$SPLASH_TARGET_DIR
 fi
 # where to icons
 if [ "x$ICO_TARGET_DIR" == "x" ] ; then
-  readonly ICO_TARGET_DIR=$TARGET/lib
+  readonly ICO_TARGET_DIR=$TARGET/libs
 else
   readonly ICO_TARGET_DIR=$ICO_TARGET_DIR
 fi
@@ -82,7 +82,7 @@ function findJar() {
 
 
 function getJar() {
-  if [ "x$ITW_LIBS" == "DISTRIBUTION" ] ; then
+  if [ "x$ITW_LIBS" == "xDISTRIBUTION" ] ; then
     findJar "$SYSTEM_JARS"  "$1"
   else
     findJar "$MAVEN_REPO" "$1"

--- a/launchers/configure.sh
+++ b/launchers/configure.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+if [ "x$JRE" == "x" ] ; then
+  echo "default jre is necessary"
+  exit 1
+else
+  readonly JRE=$JRE
+fi
+
+
+# sourced from build.sh
+readonly PROJECT_TOP=`dirname $SCRIPT_DIR`
+readonly TARGET=$SCRIPT_DIR/target
+readonly TARGET_TMP=$SCRIPT_DIR/target/tmp
+
+rm -rf "$TARGET"
+
+
+# where to search for libraris [MAVEN/SYSTEM]
+if [ "x$ITW_LIBS" = "x" ] ; then
+  ITW_LIBS="BUNDLED"
+else
+  readonly ITW_LIBS=$ITW_LIBS
+fi
+
+# where to gather external libraries
+if [ "x$LIB_TARGET_DIR" == "x" ] ; then
+  readonly LIB_TARGET_DIR=$TARGET/lib
+else
+  readonly LIB_TARGET_DIR=$LIB_TARGET_DIR
+fi
+# where to gather itw's libraries
+if [ "x$ITW_TARGET_DIR" == "x" ] ; then
+  readonly ITW_TARGET_DIR=$TARGET/lib
+else
+  readonly ITW_TARGET_DIR=$ITW_TARGET_DIR
+fi
+# where to gather config files
+if [ "x$ETC_TARGET_DIR" == "x" ] ; then
+  readonly ETC_TARGET_DIR=$TARGET/lib
+else
+  readonly ETC_TARGET_DIR=$ETC_TARGET_DIR
+fi
+# where to executables
+if [ "x$BIN_TARGET_DIR" == "x" ] ; then
+  readonly BIN_TARGET_DIR=$TARGET/bin
+else
+  readonly BIN_TARGET_DIR=$BIN_TARGET_DIR
+fi
+# where to splash
+if [ "x$SPLASH_TARGET_DIR" == "x" ] ; then
+  readonly SPLASH_TARGET_DIR=$TARGET/lib
+else
+  readonly SPLASH_TARGET_DIR=$SPLASH_TARGET_DIR
+fi
+# where to icons
+if [ "x$ICO_TARGET_DIR" == "x" ] ; then
+  readonly ICO_TARGET_DIR=$TARGET/lib
+else
+  readonly ICO_TARGET_DIR=$ICO_TARGET_DIR
+fi
+
+readonly CORE_SRC=`ls $PROJECT_TOP/core/target/icedtea-web-core-*.jar`
+readonly COMMON_SRC=`ls $PROJECT_TOP/common/target/icedtea-web-common-*.jar`
+readonly JNLPAPI_SRC=`ls $PROJECT_TOP/jnlp-api/target/jnlp-api-*.jar`
+readonly XMLPARSER_SRC=`ls $PROJECT_TOP/xml-parser/target/icedtea-web-xml-parser-*.jar`
+
+if [ "x$MAVEN_REPO" == "x" ] ; then
+  readonly MAVEN_REPO=${HOME}/.m2/
+else
+  readonly MAVEN_REPO=$MAVEN_REPO
+fi
+if [ "x$SYSTEM_JARS" == "x" ] ; then
+  readonly SYSTEM_JARS=/usr/share
+else
+  readonly SYSTEM_JARS=$SYSTEM_JARS
+fi
+
+function findJar() {
+  find "$1" 2>/dev/null | grep "$2" | grep -v -e debug -e example | grep .jar$ | sort  | tail -n 1
+}
+
+
+function getJar() {
+  if [ "x$ITW_LIBS" == "DISTRIBUTION" ] ; then
+    findJar "$SYSTEM_JARS"  "$1"
+  else
+    findJar "$MAVEN_REPO" "$1"
+  fi
+}
+
+
+if [ "x$RHINO_SRC" == "x" ] ; then
+  readonly RHINO_SRC=`getJar "rhino"`
+else
+  readonly RHINO_SRC=$RHINO_SRC
+fi
+if [ "x$TAGSOUP_SRC" == "x" ] ; then
+  readonly TAGSOUP_SRC=`getJar "tagsoup"`
+else
+  readonly TAGSOUP_SRC=$TAGSOUP_SRC
+fi
+if [ "x$SLFAPI_SRC" == "x" ] ; then
+  readonly SLFAPI_SRC=`getJar "slf4j-api"`
+else
+  readonly SLFAPI_SRC=$SLFAPI_SRC
+fi
+if [ "x$SLFSIMPLE_SRC" == "x" ] ; then
+  readonly SLFSIMPLE_SRC=`getJar "slf4j-simple"`
+else
+  readonly SLFSIMPLE_SRC=$SLFSIMPLE_SRC
+fi
+if [ "x$MSLINKS_SRC" == "x" ] ; then
+  readonly MSLINKS_SRC=`getJar "mslinks"`
+else
+  readonly MSLINKS_SRC=$MSLINKS_SRC
+fi
+
+readonly SPLASH_PNG_SRC=`find $PROJECT_TOP/core/src |  grep /javaws_splash.png$`
+readonly JAVAWS_ICO_SRC=`find $SCRIPT_DIR |  grep /javaws.png$`
+readonly MODULARJDK_ARGS_FILE_SRC=`find $SCRIPT_DIR |  grep /itw-modularjdk.args$` 
+
+if [ "x$KCOV_HOME" == "x" ] ; then
+  readonly KCOV_HOME=$HOME/kcov-master
+else
+  readonly KCOV_HOME=$KCOV_HOME
+fi
+
+# https://github.com/SimonKagstrom/kcov/
+KCOV="none" ;
+	if [ -f $KCOV_HOME/kcov ] ; then
+	  KCOV=$KCOV_HOME/kcov ;
+	elif [ -f $KCOV_HOME/bin/kcov ] ; then
+	  KCOV=$KCOV_HOME/bin/kcov ;
+	elif [ -f $KCOV_HOME/build/kcov ] ; then
+	  KCOV=$KCOV_HOME/build/kcov ;
+	elif [ -f $KCOV_HOME/build/src/kcov ] ; then
+	  KCOV=$KCOV_HOME/build/src/kcov ;
+	else
+	  mkdir $KCOV_HOME/build ;
+	  pushd $KCOV_HOME/build ;
+	  cmake .. ;
+	  make ;
+	  popd ;
+	  KCOV=$KCOV_HOME/build/src/kcov ;
+	fi ;
+
+

--- a/launchers/pom.xml
+++ b/launchers/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adoptopenjdk</groupId>
+        <artifactId>icedtea-web-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>icedtea-web-launchers</artifactId>
+    <name>Launchers</name>
+    <description>Set of default native and shell launchers for ITW</description>
+    <packaging>pom</packaging>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnlp-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>icedtea-web-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>icedtea-web-xml-parser</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>launchers</id>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <artifactId>exec-maven-plugin</artifactId>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <version>1.6.0</version>
+                            <executions>
+                                <execution>
+                                <id>build-launchers</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/build.sh</commandlineArgs>
+                                    <outputFile>${basedir}/build.log</outputFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/launchers/rust-launcher/src/main.rs
+++ b/launchers/rust-launcher/src/main.rs
@@ -108,28 +108,18 @@ fn main() {
 }
 
 fn compose_arguments(java_dir: &std::path::PathBuf, original_args: &std::vec::Vec<String>, os: &os_access::Os) -> Vec<String> {
-    let hard_bootcp = hardcoded_paths::get_bootcp();
     let bootcp = jars_helper::get_bootclasspath(&java_dir, os);
     let cp = jars_helper::get_classpath(&java_dir, os);
     let current_name = dirs_paths_helper::current_program_name();
     let current_bin = dirs_paths_helper::current_program();
     let mut info2 = String::new();
-    write!(&mut info2, "itw-rust-debug: exemplar boot classpath: {}", hard_bootcp).expect("unwrap failed");
-    os.log(&info2);
-    info2 = String::new();
     write!(&mut info2, "itw-rust-debug: used boot classpath: {}", bootcp).expect("unwrap failed");
     os.log(&info2);
     info2 = String::new();
     write!(&mut info2, "itw-rust-debug: used classpath: {}", cp).expect("unwrap failed");
     os.log(&info2);
     info2 = String::new();
-    write!(&mut info2, "itw-rust-debug: expected name: {}", hardcoded_paths::get_name()).expect("unwrap failed");
-    os.log(&info2);
-    info2 = String::new();
     write!(&mut info2, "itw-rust-debug: current name: {}", current_name).expect("unwrap failed");
-    os.log(&info2);
-    info2 = String::new();
-    write!(&mut info2, "itw-rust-debug: installed bin: {}", hardcoded_paths::get_bin()).expect("unwrap failed");
     os.log(&info2);
     info2 = String::new();
     write!(&mut info2, "itw-rust-debug: current bin: {}", &dirs_paths_helper::path_to_string(&current_bin)).expect("unwrap failed");
@@ -155,14 +145,6 @@ fn compose_arguments(java_dir: &std::path::PathBuf, original_args: &std::vec::Ve
     }
     if is_modular_jdk(os, &java_dir) {
         all_args.push(resolve_argsfile(os));
-        let js_object_candidate = get_jsobject_patchmodule(os);
-        match js_object_candidate {
-            Some(js_object_path) => {
-                all_args.push(js_object_path.0);
-                all_args.push(js_object_path.1);
-            }
-            _none => {}
-        }
     }
     all_args.push(bootcp);
     all_args.push(String::from("-classpath"));
@@ -227,25 +209,6 @@ fn resolve_argsfile(os: &os_access::Os) -> String {
     owned_string.insert_str(0, splash_switch);
     let r = String::from(owned_string);
     r
-}
-
-
-fn get_jsobject_patchmodule(os: &os_access::Os) -> Option<(String, String)> {
-    let js_object_candidate = jars_helper::resolve_jsobject(os);
-    match js_object_candidate {
-        Some(js_object_path) => {
-            let args_location = dirs_paths_helper::path_to_string(&js_object_path);
-            let mut owned_string: String = args_location.to_owned();
-            let splash_switch: &str = "jdk.jsobject=";
-            owned_string.insert_str(0, splash_switch);
-            let r = String::from(owned_string);
-            let tuple = ("--patch-module".to_string(), r);
-            return Some(tuple)
-        }
-        None => {
-            return None
-        }
-    }
 }
 
 fn get_splash(os: &os_access::Os) -> Option<String> {

--- a/launchers/rust-launcher/src/property_from_file.rs
+++ b/launchers/rust-launcher/src/property_from_file.rs
@@ -33,7 +33,7 @@ impl Validator for JreValidator {
     fn get_fail_message(&self, key: &str, value: &str, file: &Option<std::path::PathBuf>) -> String {
         let mut res = String::new();
         write!(&mut res, "Your custom JRE {} read from {} under key {} is not valid.", value, file.clone().expect("jre path should be loaded").display(), key).expect("unwrap failed");
-        write!(&mut res, " Trying other config files, then using default ({}, {}, registry or JAVA_HOME) in attempt to start. Please fix this.", hardcoded_paths::get_java(), hardcoded_paths::get_jre()).expect("unwrap failed");
+        write!(&mut res, " Trying other config files, then using default ({}, {}, registry or JAVA_HOME) in attempt to start. Please fix this.", hardcoded_paths::get_jre(), hardcoded_paths::get_jre()).expect("unwrap failed");
         return res;
     }
 }

--- a/launchers/rust-launcher/src/utils.rs
+++ b/launchers/rust-launcher/src/utils.rs
@@ -34,6 +34,9 @@ pub fn find_jre(os: &os_access::Os) -> std::path::PathBuf {
                 }
                 Err(_e) => {
                     os.log("itw-rust-debug: nothing");
+                    if hardcoded_paths::get_libsearch(os) == hardcoded_paths::ItwLibSearch::EMBEDDED {
+                        // TODO determine embedded JRE
+                    }
                     os.log("itw-rust-debug: trying jdk from registry");
                     match os.get_registry_java() {
                         Some(path) => {
@@ -77,8 +80,8 @@ fn get_jdk_from_path_conditionally_testable(system_path: Option<OsString>, libse
         os.log("itw-rust-debug: skipping jdk from path, your build is distribution");
         None
     } else {
-        if libsearch == hardcoded_paths::ItwLibSearch::BOTH {
-            os.important("your build is done as BOTH distribution and bundled, jdk from PATH may be not what you want!");
+        if libsearch == hardcoded_paths::ItwLibSearch::EMBEDDED {
+            os.important("your build is done as EMBEDDED, jdk from PATH may be not what you want!");
         }
         get_jdk_from_given_path_testable(system_path, os)
     }
@@ -160,13 +163,13 @@ pub mod tests_utils {
                    None);
         assert_eq!(super::get_jdk_from_path_conditionally_testable(None, hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new()),
                    None);
-        assert_eq!(super::get_jdk_from_path_conditionally_testable(None, hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new()),
+        assert_eq!(super::get_jdk_from_path_conditionally_testable(None, hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new()),
                    None);
         assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new()),
                    None);
         assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new()),
                    None);
-        assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new()),
+        assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new()),
                    None);
     }
 
@@ -177,7 +180,7 @@ pub mod tests_utils {
         master_dir.push("bin");
         let v1 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new());
         let v2 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new());
-        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new());
+        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new());
         debuggable_remove_dir(&master_dir);
         assert_eq!(None, v1);
         assert_eq!(Some(top_dir.clone()), v2);
@@ -189,7 +192,7 @@ pub mod tests_utils {
         let master_dir = fake_jre(false);
         let v1 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new());
         let v2 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new());
-        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new());
+        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new());
         debuggable_remove_dir(&master_dir);
         assert_eq!(None, v1);
         assert_eq!(None, v2);
@@ -206,7 +209,7 @@ pub mod tests_utils {
         File::create(&fake_jre).expect("File created");
         let v1 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new());
         let v2 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new());
-        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new());
+        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new());
         debuggable_remove_dir(&master_dir);
         assert_eq!(None, v1);
         let parent = dirs_paths_helper::canonicalize(&std::path::PathBuf::from(master_dir.parent().expect("just created"))).expect("canonicalize failed");

--- a/launchers/shell-launcher/launchers.sh.in
+++ b/launchers/shell-launcher/launchers.sh.in
@@ -1,27 +1,37 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
+if echo "'$*'" | grep -e "-verbose" ; then
+  set -x
+fi
+
 NASHORN=lib/ext/nashorn.jar
 JRE=@JRE@
-#unused
-JAVA=$JRE/bin/java
-LAUNCHER_BOOTCLASSPATH='@LAUNCHER_BOOTCLASSPATH@'
 LAUNCHER_FLAGS=-Xms8m
-CLASSNAME=@MAIN_CLASS@
-BINARY_LOCATION=@BIN_LOCATION@
-SPLASH_LOCATION=@JAVAWS_SPLASH_LOCATION@
+MAIN_CLASS=@MAIN_CLASS@
+SPLASH_PNG=@SPLASH_PNG@
 RUN_ARGS_LOCATION=@MODULARJDK_ARGS_LOCATION@
-PROGRAM_NAME=@PROGRAM_NAME@
-CP=$JRE/lib/rt.jar:$JRE/lib/ext/jfxrt.jar
+ITW_LIBS=@ITW_LIBS@
 
-# individual parts of bootclasspath for more easy processing
-NETX_JAR=@NETX_JAR@
-PLUGIN_JAR=@PLUGIN_JAR@
-JSOBJECT_JAR=@JSOBJECT_JAR@
+# individual parts of bootclasspath
+CORE_JAR=@CORE_JAR@
+COMMON_JAR=@COMMON_JAR@
+JNLPAPI_JAR=@JNLPAPI_JAR@
+XMLPARSER_JAR=@XMLPARSER_JAR@
+SLFAPI_JAR=@SLFAPI_JAR@
+SLFSIMPLE_JAR=@SLFSIMPLE_JAR@
 TAGSOUP_JAR=@TAGSOUP_JAR@
 RHINO_JAR=@RHINO_JAR@
-# windows only:
-#MSLINKS_JAR=@MSLINKS_JAR@
+# windows only: (cywin usage?); need to decare it anyway
+MSLINKS_JAR=@MSLINKS_JAR@
 
+if [ "x$ITW_LIBS" == "xEMBEDDED" ] ; then
+ echo "ITW_LIBS=EMBEDDED not (yet?) supported"
+ exit 1
+fi
 
 ## resolve folder of this script, following all symlinks:
 ## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
@@ -34,9 +44,11 @@ while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer 
 done
 readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
 readonly PORTABLE_ITW_HOME="`dirname $SCRIPT_DIR`"
+BINARY_LOCATION="$SCRIPT_DIR/`basename $SCRIPT_SOURCE`"
 
 
 ## resolve custom JRE:
+set +ue
 CONFIG_HOME=$XDG_CONFIG_HOME
 if [ "x$CONFIG_HOME" = "x" ] ; then
   CONFIG_HOME=~/.config
@@ -56,29 +68,38 @@ if [ ! "x$JAVA_HOME" = "x" ] ; then
   echo "Warning! JAVA_HOME of $JAVA_HOME in play!"
   CUSTOM_JRE=$JAVA_HOME
 fi
-
+set -ue
 
 # Support portable ITW:
 # note, that this is temporary, experimental solution, moreover for 1.7 and will likely change since 1.8
 # by this, sh launchers can be again a bit more portable then win ones, thats why we moved to native ones since 1.8
 # still this is very dummy
-if [ ! -f $NETX_JAR ] ; then
-  ITW_LIBS="BUNDLED";
-fi
+function locallib() {
+  echo "$ITW_HOME/libs/`basename \"$1\"`"
+}
+
+set +u
 if [ "x$ITW_LIBS" == "xBUNDLED" -o ! "x$ITW_HOME" = "x" ] ; then
   if [ "x$ITW_HOME" = "x" ] ; then
     ITW_HOME=$PORTABLE_ITW_HOME
   fi
+  set -u
   BINARY_LOCATION="$ITW_HOME/bin/`basename \"$BINARY_LOCATION\"`"
-  SPLASH_LOCATION="$ITW_HOME/share/icedtea-web/`basename \"$SPLASH_LOCATION\"`"
-  RUN_ARGS_LOCATION="$ITW_HOME/bin/`basename \"$RUN_ARGS_LOCATION\"`"
-  NETX_JAR="$ITW_HOME/share/icedtea-web/`basename \"$NETX_JAR\"`"
-  PLUGIN_JAR="$ITW_HOME/share/icedtea-web/`basename \"$PLUGIN_JAR\"`"
-  JSOBJECT_JAR="$ITW_HOME/share/icedtea-web/`basename \"$JSOBJECT_JAR\"`"
-  LAUNCHER_BOOTCLASSPATH="-Xbootclasspath/a:$NETX_JAR:$PLUGIN_JAR:$JSOBJECT_JAR:$ITW_HOME/linux-deps-runtime/`basename \"$TAGSOUP_JAR\"`:$ITW_HOME/linux-deps-runtime/`basename \"$RHINO_JAR\"`"
-  echo "warning, using portable itw from $ITW_HOME: $LAUNCHER_BOOTCLASSPATH $BINARY_LOCATION $SPLASH_LOCATION"
+  SPLASH_PNG="`locallib \"$SPLASH_PNG\"`"
+  RUN_ARGS_LOCATION="`locallib \"$RUN_ARGS_LOCATION\"`"
+  CORE_JAR="`locallib  \"$CORE_JAR\"`"
+  COMMON_JAR="`locallib  \"$COMMON_JAR\"`"
+  JNLPAPI_JAR="`locallib  \"$JNLPAPI_JAR\"`"
+  XMLPARSER_JAR="`locallib  \"$XMLPARSER_JAR\"`"
+  RHINO_JAR="`locallib  \"$RHINO_JAR\"`"
+  TAGSOUP_JAR="`locallib  \"$TAGSOUP_JAR\"`"
+  SLFAPI_JAR="`locallib  \"$SLFAPI_JAR\"`"
+  SLFSIMPLE_JAR="`locallib  \"$SLFSIMPLE_JAR\"`"
+  MSLINKS_JAR="`locallib  \"$MSLINKS_JAR\"`"
+  echo "warning, using portable itw from $ITW_HOME"
 fi
-
+set -u
+LAUNCHER_BOOTCLASSPATH="-Xbootclasspath/a:$CORE_JAR:$COMMON_JAR:$JNLPAPI_JAR:$XMLPARSER_JAR:$TAGSOUP_JAR:$RHINO_JAR:$SLFAPI_JAR:$SLFSIMPLE_JAR:$MSLINKS_JAR"
 
 # Fix classpaths for custom JRE:
 if [ "x$CUSTOM_JRE" != "x" ] ; then
@@ -90,6 +111,8 @@ if [ "x$CUSTOM_JRE" != "x" ] ; then
     echo "Your custom JRE $CUSTOM_JRE read from deployment.properties under key $PROPERTY_NAME as $CUSTOM_JRE is not valid. Using default ($JRE, $CP) in attempt to start. Please fix this."
   fi
 else
+  JAVA=$JRE/bin/java
+  CP=$JRE/lib/rt.jar:$JRE/lib/ext/jfxrt.jar
   LAUNCHER_BOOTCLASSPATH="$LAUNCHER_BOOTCLASSPATH:$JRE/$NASHORN"
 fi;
 
@@ -116,10 +139,11 @@ j=0
 
 # Filter script args:
 SPLASH="false"
+set +u
 if [ "x$ICEDTEA_WEB_SPLASH" = "x" ] ; then
   SPLASH="true"
 fi;
-
+set -u
 while [ "$#" -gt "0" ]; do
   case "$1" in
     -J*)
@@ -142,7 +166,7 @@ k=0
 COMMAND[k]="${JAVA}"
 k=$((k+1))
 if [ "$SPLASH" = "true" ] ; then
-  COMMAND[k]="-splash:${SPLASH_LOCATION}"
+  COMMAND[k]="-splash:${SPLASH_PNG}"
   k=$((k+1))
 fi;
 COMMAND[k]="${LAUNCHER_BOOTCLASSPATH}"
@@ -151,20 +175,6 @@ COMMAND[k]="${LAUNCHER_FLAGS}"
 k=$((k+1))
 
 if [ "x$MODULAR_JDK" == "xYES" ] ; then
-  COMMAND[k]="--patch-module"
-  k=$((k+1))
-  COMMAND[k]="java.desktop=$NETX_JAR:$PLUGIN_JAR"
-  k=$((k+1))
-  # jsobject must be patched separately from plugin
-  # otherwise netscape pkg would be shared by two modules, which is forbiden
-  # plugin jar may not be built
-  if [ ! "x$JSOBJECT_JAR" == "x" ] ; then
-    COMMAND[k]="--patch-module"
-    k=$((k+1))
-    COMMAND[k]="jdk.jsobject=$JSOBJECT_JAR"
-    k=$((k+1))
-  fi
-
   # add JDK9+ arg file:
   COMMAND[k]="@$RUN_ARGS_LOCATION"
   k=$((k+1))
@@ -183,12 +193,12 @@ k=$((k+1))
 COMMAND[k]="${CP}"
 k=$((k+1))
 
-COMMAND[k]="-Dicedtea-web.bin.name=${PROGRAM_NAME}"
+COMMAND[k]="-Dicedtea-web.bin.name=`basename $SCRIPT_SOURCE`"
 k=$((k+1))
 COMMAND[k]="-Dicedtea-web.bin.location=${BINARY_LOCATION}"
 k=$((k+1))
 
-COMMAND[k]="${CLASSNAME}"
+COMMAND[k]="${MAIN_CLASS}"
 k=$((k+1))
 j=0
 while [ "$j" -lt "${#ARGS[@]}" ]; do
@@ -197,7 +207,7 @@ while [ "$j" -lt "${#ARGS[@]}" ]; do
   k=$((k+1))
 done
 
-exec -a "$PROGRAM_NAME" "${COMMAND[@]}"
+exec -a "`basename $SCRIPT_SOURCE`" "${COMMAND[@]}"
 
 exit $?
 


### PR DESCRIPTION
Hi!

this is adaptng launchers to now build. By default, they are nto build. You must use profile launchers to get them. Both shell and native ones are processed.  BOTH buuilt style was dropped, libs were narrowed.

The major usage would be:

MSLINKS_SRC=/home/blah/.m2/repository/com/github/vatbub/mslinks/1.0.5/mslinks-1.0.5.jar ITW_LIBS=DISTRIBUTION JRE=/usr/lib/jvm/java-1.8.0-openjdk mvn clean install -Plaunchers

and

ITW_LIBS=BUNDLED JRE=/usr/lib/jvm/java-1.8.0-openjdk mvn clean install -Plaunchers

All jars locations can be overwritten via variables. I have not found a better way in maven-shell connection.

This is still build only, .bats are missing (for now) and images (and thus msi) will come later.
