### PR TITLE
Default launchers images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 *.log
 ServerAccess-logs.xml
+launchers/build.log
+launchers/rust-launcher/Cargo.lock

--- a/launchers/configure.sh
+++ b/launchers/configure.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+VERSION=$1
+
+if [ "x$VERSION"  == "x" ] ; then
+ readonly VERSION="unknown"
+else
+ readonly VERSION=$VERSION
+fi
+
 if [ "x$JRE" == "x" ] ; then
   echo "default jre is necessary"
   exit 1
@@ -11,7 +19,8 @@ fi
 # sourced from build.sh
 readonly PROJECT_TOP=`dirname $SCRIPT_DIR`
 readonly TARGET=$SCRIPT_DIR/target
-readonly TARGET_TMP=$SCRIPT_DIR/target/tmp
+readonly TARGET_TMP=$TARGET/tmp
+readonly TARGET_IMAGES=$TARGET/images
 
 rm -rf "$TARGET"
 
@@ -146,4 +155,16 @@ KCOV="none" ;
 	  KCOV=$KCOV_HOME/build/src/kcov ;
 	fi ;
 
+if [ "x$CARGO_RUST" == "x" ] ; then
+  readonly CARGO_RUST=cargo
+else
+  readonly CARGO_RUST="$CARGO_RUST"
+fi
 
+isWindows() {
+  if [[ $( uname ) == *"NT"* ]]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/launchers/pom.xml
+++ b/launchers/pom.xml
@@ -62,6 +62,18 @@
                                     <outputFile>${basedir}/build.log</outputFile>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>clean-launchers</id>
+                                <phase>clean</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>rm</executable>
+                                    <commandlineArgs>-rvf ${basedir}/target  ${basedir}/rust-launcher/target/</commandlineArgs>
+                                    <outputFile>${basedir}/build.log</outputFile>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/launchers/pom.xml
+++ b/launchers/pom.xml
@@ -58,7 +58,7 @@
                                 </goals>
                                 <configuration>
                                     <executable>bash</executable>
-                                    <commandlineArgs>${basedir}/build.sh</commandlineArgs>
+                                    <commandlineArgs>${basedir}/build.sh ${project.version}</commandlineArgs>
                                     <outputFile>${basedir}/build.log</outputFile>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Rust and shell launchers now generate distributable images.
Added clean phase
The images have version inherited from main pom
launchers/build.log and cargo.lock added to .gitignore