### PR TITLE
fix problems with shutdown hock of OutputController

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/console/JavaConsole.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/console/JavaConsole.java
@@ -105,6 +105,9 @@ public class JavaConsole implements ObservableMessagesProvider {
         System.setOut(new TeeOutputStream(System.out, false));
         //internal stdOut/Err are going throughs outLog/errLog
         //when console is off, those tees are not installed
+
+        // initialize SwingUtils
+        updateModel();
     }
 
     private void refreshOutputs() {

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
@@ -456,9 +456,9 @@ public class JNLPRuntime {
      */
     private static class DeploymentConfigurationHolder {
 
-        private static final DeploymentConfiguration INSTANCE = initConfiguration();
+        private static final DeploymentConfiguration INSTANCE;
 
-        private static DeploymentConfiguration initConfiguration() {
+        static {
             DeploymentConfiguration config = new DeploymentConfiguration();
             try {
                 config.load();
@@ -476,9 +476,9 @@ public class JNLPRuntime {
                 //try to survive this unlikely exception
                 config.resetToDefaults();
             } finally {
+                INSTANCE = config;
                 OutputController.getLogger().startConsumer();
             }
-            return config;
         }
     }
 


### PR DESCRIPTION
`OutputController.flush()` is called in the shutdown hook of the OutputController.
If flush() has not been called before the shutdown hook is executed then the code was trying to initialize the awt toolkit.
The windows implementation of the toolkit will try to register another shutdown hook.
This fails if the shutdown is already in progress. The failure is unfortunately not handled very clean by the toolkit. As a consequence a thread is left in a `wait(0)` where it will stay forever.
This change makes sure that if flush is called during shutdown and the SwingUtils are not initialized then they will not be initialized.