### PR TITLE
refactored SecurityDesc

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/AppletPermissionLevel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/AppletPermissionLevel.java
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 Karakun AG
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+package net.adoptopenjdk.icedteaweb.jnlp.element.security;
+
+/**
+ * Specifies the level of permissions that the applet needs to run. Specify "sandbox" for the
+ * value to run in the sandbox. Specify "all-permissions" to run outside the sandbox.
+ * <p/>
+ * Applet permissions are specified in the applet html page file as sub element
+ * {@code <param name="permissions" value="sandbox"/>} of the applet tag.
+ *
+ * If this parameter is omitted, {@code default} is assumed which is determined by
+ * the {@code Permissions} attribute in the manifest for the main JAR file.
+ *
+ * (see https://docs.oracle.com/javase/8/docs/technotes/guides/deploy/applet_dev_guide.html#JSDPG709).
+ * <p/>
+ *  or the
+ * {@code Permissions: sandbox} attribute in the manifest for the main JAR file.
+ *
+ * @see SecurityDesc
+ */
+public enum AppletPermissionLevel {
+    /**
+     * The all-permissions indicates that the RIA needs full access the the local
+     * system and network.
+     */
+    ALL("all-permissions"),
+
+    /**
+     * Indicates that the RIA runs in the security sandbox and does not require additional permissions.
+     */
+    SANDBOX("sandbox"),
+
+    /**
+     * Indicates that the level of permissions is determined by the {@code Permissions} attribute in the manifest
+     * for the main JAR file.
+     */
+    DEFAULT("default"),
+
+    /**
+     * Indicates that no applet permissions are specified.
+     * @deprecated
+     */
+    @Deprecated
+    // consider to handle the absence of an permissions param different
+    // as there is no such thing as NONE in the specs
+    NONE(null);
+
+    private String value;
+
+    AppletPermissionLevel(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/AppletPermissionLevel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/AppletPermissionLevel.java
@@ -60,9 +60,9 @@ public enum AppletPermissionLevel {
     // as there is no such thing as NONE in the specs
     NONE(null);
 
-    private String value;
+    private final String value;
 
-    AppletPermissionLevel(String value) {
+    AppletPermissionLevel(final String value) {
         this.value = value;
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/ApplicationPermissionLevel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/ApplicationPermissionLevel.java
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 Karakun AG
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+package net.adoptopenjdk.icedteaweb.jnlp.element.security;
+
+/**
+ * The permissions that could be requested by a trusted environment. JSR-56 specifies two trusted environments,
+ * the all-permissions environment and an environment that meets the security specifications of the J2EE
+ * Application Client environment.
+ * <p/>
+ * JSR-56, Section 5.6 also lists the two default permission sets that must be granted to the application's
+ * resources to a trusted application or applet requesting all-permissions or
+ * j2ee-application-client-permissions.
+ * <p/>
+ *
+ * @implSpec See <b>JSR-56, Section 5.6 Trusted Environments</b>
+ * for a detailed specification of this class.
+ * @see SecurityDesc
+ */
+public enum ApplicationPermissionLevel {
+    /**
+     * The all-permissions indicates that the application needs full access the the local
+     * system and network.
+     */
+    ALL("all-permissions"),
+
+    /**
+     * The j2ee-application-client-permissions element indicates that the application needs the set of
+     * permissions defined for a J2EE application client.
+     */
+    J2EE("j2ee-application-client-permissions"),
+
+    /**
+     * Indicates that no application permissions are specified.
+     * @deprecated
+     */
+    @Deprecated
+    // consider to handle the absence of a security element in the jnlp file different
+    // as there is no such thing as NONE in the specs
+    NONE(null);
+
+    private String value;
+
+    ApplicationPermissionLevel(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/ApplicationPermissionLevel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/ApplicationPermissionLevel.java
@@ -52,9 +52,9 @@ public enum ApplicationPermissionLevel {
     // as there is no such thing as NONE in the specs
     NONE(null);
 
-    private String value;
+    private final String value;
 
-    ApplicationPermissionLevel(String value) {
+    ApplicationPermissionLevel(final String value) {
         this.value = value;
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/SecurityDesc.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/SecurityDesc.java
@@ -130,8 +130,8 @@ public class SecurityDesc {
      * when the SecurityDesc is constructed, rather than every time a call is made to
      * {@link SecurityDesc#getSandBoxPermissions()}, which is called frequently.
      */
-    private static Class<Permission> urlPermissionClass = null;
-    private static Constructor<Permission> urlPermissionConstructor = null;
+    private static Class<Permission> urlPermissionClass;
+    private static Constructor<Permission> urlPermissionConstructor;
     
     static {
         try {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/SecurityDesc.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/SecurityDesc.java
@@ -240,7 +240,7 @@ public class SecurityDesc {
      * @param type the type of security
      * @param downloadHost the download host (can always connect to)
      */
-    public SecurityDesc(JNLPFile file, ApplicationPermissionLevel applicationPermissionLevel, Object type, URL downloadHost) {
+    public SecurityDesc(final JNLPFile file, final ApplicationPermissionLevel applicationPermissionLevel, final Object type, final URL downloadHost) {
         if (file == null) {
             throw new NullJnlpFileException();
         }
@@ -263,7 +263,7 @@ public class SecurityDesc {
      * @param type the type of security
      * @param downloadHost the download host (can always connect to)
      */
-    public SecurityDesc(JNLPFile file, AppletPermissionLevel appletPermissionLevel, Object type, URL downloadHost) {
+    public SecurityDesc(final JNLPFile file, final AppletPermissionLevel appletPermissionLevel, final Object type, final URL downloadHost) {
         if (file == null) {
             throw new NullJnlpFileException();
         }

--- a/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
+++ b/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
@@ -88,8 +88,8 @@ public class JNLPFile {
     public static final String SPEC_ATTRIBUTE = "spec";
     public static final String VERSION_ATTRIBUTE = "version";
 
-    public static enum ManifestBoolean {
-        TRUE, FALSE, UNDEFINED;
+    public enum ManifestBoolean {
+        TRUE, FALSE, UNDEFINED
     }
    
 
@@ -129,7 +129,7 @@ public class JNLPFile {
     protected List<ResourcesDesc> resources;
 
     /** additional resources not in JNLP file (from command line) */
-    protected ResourcesDesc sharedResources = new ResourcesDesc(this, null, null, null);
+    protected final ResourcesDesc sharedResources = new ResourcesDesc(this, null, null, null);
 
     /** the application entry point */
     protected EntryPoint entryPointDesc;
@@ -807,7 +807,7 @@ public class JNLPFile {
      * @return true if prefixStr is a prefix of any strings in
      * available, or if available is empty or null.
      */
-    static boolean stringMatches(String prefixStr, String available[]) {
+    static boolean stringMatches(String prefixStr, String[] available) {
         if (available == null || available.length == 0){
             return true;
         }
@@ -1076,7 +1076,7 @@ public class JNLPFile {
                 return ManifestBoolean.UNDEFINED;
             } else if (permissionLevel.trim().equalsIgnoreCase(AppletPermissionLevel.SANDBOX.getValue())) {
                 return ManifestBoolean.TRUE;
-            } else if (permissionLevel.trim().equalsIgnoreCase(getAppletPermissionLevel().ALL.getValue())) {
+            } else if (permissionLevel.trim().equalsIgnoreCase(AppletPermissionLevel.ALL.getValue())) {
                 return ManifestBoolean.FALSE;
             } else {
                 throw new IllegalArgumentException(
@@ -1090,7 +1090,7 @@ public class JNLPFile {
          * @return plain string values of Permissions manifest attribute
          */
         public String permissionsToString() {
-            String s = getManifestPermissionsAttribute();
+            final String s = getManifestPermissionsAttribute();
             if (s == null) {
                 return "Not defined";
             } else if (s.trim().equalsIgnoreCase(AppletPermissionLevel.SANDBOX.getValue())) {

--- a/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
+++ b/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
@@ -26,8 +26,9 @@ import net.adoptopenjdk.icedteaweb.jnlp.element.information.InformationDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JREDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.PropertyDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.ApplicationPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc.RequestedPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.element.update.UpdateDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.version.Version;
 import net.adoptopenjdk.icedteaweb.xmlparser.Node;
@@ -599,8 +600,18 @@ public class JNLPFile {
         return security;
     }
 
-    public RequestedPermissionLevel getRequestedPermissionLevel() {
-        return this.security.getRequestedPermissionLevel();
+    /**
+     * @return the requested security level of the application represented by this JNLP file.
+     */
+    public ApplicationPermissionLevel getApplicationPermissionLevel() {
+        return this.security.getApplicationPermissionLevel();
+    }
+
+    /**
+     * @return the requested security level of the applet represented by this JNLP file.
+     */
+    public AppletPermissionLevel getAppletPermissionLevel() {
+        return this.security.getAppletPermissionLevel();
     }
 
     /**
@@ -1060,34 +1071,39 @@ public class JNLPFile {
          * @return value of Permissions manifest attribute
          */
         public ManifestBoolean isSandboxForced() {
-            String s = getAttribute(PERMISSIONS);
-            if (s == null) {
+            String permissionLevel = getManifestPermissionsAttribute();
+            if (permissionLevel == null) {
                 return ManifestBoolean.UNDEFINED;
-            } else if (s.trim().equalsIgnoreCase(SecurityDesc.RequestedPermissionLevel.SANDBOX.toHtmlString())) {
+            } else if (permissionLevel.trim().equalsIgnoreCase(AppletPermissionLevel.SANDBOX.getValue())) {
                 return ManifestBoolean.TRUE;
-            } else if (s.trim().equalsIgnoreCase(SecurityDesc.RequestedPermissionLevel.ALL.toHtmlString())) {
+            } else if (permissionLevel.trim().equalsIgnoreCase(getAppletPermissionLevel().ALL.getValue())) {
                 return ManifestBoolean.FALSE;
             } else {
-                throw new IllegalArgumentException("Unknown value of " + PERMISSIONS + " attribute " + s + ". Expected "+SecurityDesc.RequestedPermissionLevel.SANDBOX.toHtmlString()+" or "+SecurityDesc.RequestedPermissionLevel.ALL.toHtmlString());
+                throw new IllegalArgumentException(
+                        String.format("Unknown value of %s attribute %s. Expected %s or %s", PERMISSIONS, permissionLevel,
+                                AppletPermissionLevel.SANDBOX.getValue(), AppletPermissionLevel.ALL.getValue())
+                );
             }
-
-
         }
         /**
          * http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html#permissions
          * @return plain string values of Permissions manifest attribute
          */
         public String permissionsToString() {
-            String s = getAttribute(PERMISSIONS);
+            String s = getManifestPermissionsAttribute();
             if (s == null) {
                 return "Not defined";
-            } else if (s.trim().equalsIgnoreCase(SecurityDesc.RequestedPermissionLevel.SANDBOX.toHtmlString())) {
+            } else if (s.trim().equalsIgnoreCase(AppletPermissionLevel.SANDBOX.getValue())) {
                 return s.trim();
-            } else if (s.trim().equalsIgnoreCase(SecurityDesc.RequestedPermissionLevel.ALL.toHtmlString())) {
+            } else if (s.trim().equalsIgnoreCase(AppletPermissionLevel.ALL.getValue())) {
                 return s.trim();
             } else {
                 return "illegal";
             }
+        }
+
+        String getManifestPermissionsAttribute() {
+            return getAttribute(PERMISSIONS);
         }
 
         /**

--- a/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
+++ b/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
@@ -1071,7 +1071,7 @@ public class JNLPFile {
          * @return value of Permissions manifest attribute
          */
         public ManifestBoolean isSandboxForced() {
-            String permissionLevel = getManifestPermissionsAttribute();
+            final String permissionLevel = getManifestPermissionsAttribute();
             if (permissionLevel == null) {
                 return ManifestBoolean.UNDEFINED;
             } else if (permissionLevel.trim().equalsIgnoreCase(AppletPermissionLevel.SANDBOX.getValue())) {

--- a/core/src/main/java/net/sourceforge/jnlp/Parser.java
+++ b/core/src/main/java/net/sourceforge/jnlp/Parser.java
@@ -39,8 +39,8 @@ import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JREDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.PackageDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.PropertyDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.ApplicationPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc.RequestedPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.element.update.UpdateCheck;
 import net.adoptopenjdk.icedteaweb.jnlp.element.update.UpdateDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.update.UpdatePolicy;
@@ -80,6 +80,7 @@ import static net.adoptopenjdk.icedteaweb.jnlp.element.information.HomepageDesc.
 import static net.adoptopenjdk.icedteaweb.jnlp.element.information.InformationDesc.INFORMATION_ELEMENT;
 import static net.adoptopenjdk.icedteaweb.jnlp.element.information.InformationDesc.LOCALE_ATTRIBUTE;
 import static net.adoptopenjdk.icedteaweb.jnlp.element.information.RelatedContentDesc.RELATED_CONTENT_ELEMENT;
+import static net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc.SECURITY_ELEMENT;
 import static net.adoptopenjdk.icedteaweb.jnlp.element.update.UpdateDesc.UPDATE_ELEMENT;
 import static net.adoptopenjdk.icedteaweb.xmlparser.XMLParser.addSlash;
 import static net.adoptopenjdk.icedteaweb.xmlparser.XMLParser.getAttribute;
@@ -698,8 +699,8 @@ public final class Parser {
      * @param parent the parent node
      * @throws ParseException if the JNLP file is invalid
      */
-    public SecurityDesc getSecurity(Node parent) throws ParseException {
-        Node nodes[] = getChildNodes(parent, "security");
+    public SecurityDesc getSecurity(final Node parent) throws ParseException {
+        final Node nodes[] = getChildNodes(parent, SECURITY_ELEMENT);
 
         // test for too many security elements
         if (nodes.length > 1) {
@@ -709,25 +710,25 @@ public final class Parser {
         }
 
         Object type = SecurityDesc.SANDBOX_PERMISSIONS;
-        RequestedPermissionLevel requestedPermissionLevel = RequestedPermissionLevel.NONE;
+        ApplicationPermissionLevel applicationPermissionLevel = ApplicationPermissionLevel.NONE;
 
         if (nodes.length == 0) {
             type = SecurityDesc.SANDBOX_PERMISSIONS;
-            requestedPermissionLevel = RequestedPermissionLevel.NONE;
-        } else if (null != getChildNode(nodes[0], "all-permissions")) {
+            applicationPermissionLevel = ApplicationPermissionLevel.NONE;
+        } else if (null != getChildNode(nodes[0], ApplicationPermissionLevel.ALL.getValue())) {
             type = SecurityDesc.ALL_PERMISSIONS;
-            requestedPermissionLevel = RequestedPermissionLevel.ALL;
-        } else if (null != getChildNode(nodes[0], "j2ee-application-client-permissions")) {
+            applicationPermissionLevel = ApplicationPermissionLevel.ALL;
+        } else if (null != getChildNode(nodes[0], ApplicationPermissionLevel.J2EE.getValue())) {
             type = SecurityDesc.J2EE_PERMISSIONS;
-            requestedPermissionLevel = RequestedPermissionLevel.J2EE;
+            applicationPermissionLevel = ApplicationPermissionLevel.J2EE;
         } else if (strict) {
             throw new ParseException(R("PEmptySecurity"));
         }
 
         if (base != null) {
-            return new SecurityDesc(file, requestedPermissionLevel, type, base);
+            return new SecurityDesc(file, applicationPermissionLevel, type, base);
         } else {
-            return new SecurityDesc(file, requestedPermissionLevel, type, null);
+            return new SecurityDesc(file, applicationPermissionLevel, type, null);
         }
     }
 
@@ -735,11 +736,11 @@ public final class Parser {
      * Returns whether the JNLP file requests a trusted execution environment.
      */
     private boolean isTrustedEnvironment() {
-        Node security = getChildNode(root, "security");
+        final Node security = getChildNode(root, SECURITY_ELEMENT);
 
         if (security != null) {
-            if (getChildNode(security, "all-permissions") != null
-                    || getChildNode(security, "j2ee-application-client-permissions") != null) {
+            if (getChildNode(security, ApplicationPermissionLevel.ALL.getValue()) != null
+                    || getChildNode(security, ApplicationPermissionLevel.J2EE.getValue()) != null) {
                 return true;
             }
         }

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/ManifestAttributesChecker.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/ManifestAttributesChecker.java
@@ -43,8 +43,8 @@ import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendeds
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ExtensionDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc.RequestedPermissionLevel;
 import net.sourceforge.jnlp.JNLPFile;
 import net.sourceforge.jnlp.JNLPFile.ManifestBoolean;
 import net.sourceforge.jnlp.LaunchException;
@@ -64,8 +64,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static net.adoptopenjdk.icedteaweb.i18n.Translator.R;
 import static net.adoptopenjdk.icedteaweb.config.validators.ValidatorUtils.splitCombination;
+import static net.adoptopenjdk.icedteaweb.i18n.Translator.R;
 
 public class ManifestAttributesChecker {
 
@@ -294,16 +294,16 @@ public class ManifestAttributesChecker {
             return;
         }
 
-        final RequestedPermissionLevel requestedPermissions = file.getRequestedPermissionLevel();
-        validateRequestedPermissionLevelMatchesManifestPermissions(requestedPermissions, sandboxForced);
+        final AppletPermissionLevel requestedPermissionLevel = file.getAppletPermissionLevel();
+        validateRequestedPermissionLevelMatchesManifestPermissions(requestedPermissionLevel, sandboxForced);
         if (file instanceof PluginBridge) { // HTML applet
-            if (isNoneOrDefault(requestedPermissions)) {
+            if (isNoneOrDefault(requestedPermissionLevel)) {
                 if (sandboxForced == ManifestBoolean.TRUE && signing != SigningState.NONE) {
                     securityDelegate.setRunInSandbox();
                 }
             }
         } else { // JNLP
-            if (isNoneOrDefault(requestedPermissions)) {
+            if (isNoneOrDefault(requestedPermissionLevel)) {
                 if (sandboxForced == ManifestBoolean.TRUE && signing != SigningState.NONE) {
                     LOG.warn("The 'permissions' attribute is '{}' and the applet is signed. Forcing sandbox.", file.getManifestsAttributes().permissionsToString());
                     securityDelegate.setRunInSandbox();
@@ -320,16 +320,16 @@ public class ManifestAttributesChecker {
         return AppletStartupSecuritySettings.getInstance().getSecurityLevel().equals(AppletSecurityLevel.ALLOW_UNSIGNED);
     }
 
-    private static boolean isNoneOrDefault(final RequestedPermissionLevel requested) {
-        return requested == RequestedPermissionLevel.NONE || requested == RequestedPermissionLevel.DEFAULT;
+    private static boolean isNoneOrDefault(final AppletPermissionLevel requested) {
+        return requested == AppletPermissionLevel.NONE || requested == AppletPermissionLevel.DEFAULT;
     }
 
-    private void validateRequestedPermissionLevelMatchesManifestPermissions(final RequestedPermissionLevel requested, final ManifestBoolean sandboxForced) throws LaunchException {
-        if (requested == RequestedPermissionLevel.ALL && sandboxForced != ManifestBoolean.FALSE) {
+    private void validateRequestedPermissionLevelMatchesManifestPermissions(final AppletPermissionLevel requested, final ManifestBoolean sandboxForced) throws LaunchException {
+        if (requested == AppletPermissionLevel.ALL && sandboxForced != ManifestBoolean.FALSE) {
             throw new LaunchException("The 'permissions' attribute is '" + file.getManifestsAttributes().permissionsToString() + "' but the applet requested " + requested + ". This is fatal");
         }
 
-        if (requested == RequestedPermissionLevel.SANDBOX && sandboxForced != ManifestBoolean.TRUE) {
+        if (requested == AppletPermissionLevel.SANDBOX && sandboxForced != ManifestBoolean.TRUE) {
             throw new LaunchException("The 'permissions' attribute is '" + file.getManifestsAttributes().permissionsToString() + "' but the applet requested " + requested + ". This is fatal");
         }
     }

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/SecurityDescTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/jnlp/element/security/SecurityDescTest.java
@@ -36,9 +36,10 @@ exception statement from your version.
  */
 package net.adoptopenjdk.icedteaweb.jnlp.element.security;
 
-import java.net.URI;
 import net.adoptopenjdk.icedteaweb.testing.mock.DummyJNLPFile;
 import org.junit.Test;
+
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -49,7 +50,7 @@ public class SecurityDescTest {
     public void testNotNullJnlpFile() throws Exception {
         Throwable t = null;
         try {
-            new SecurityDesc(new DummyJNLPFile(), SecurityDesc.SANDBOX_PERMISSIONS, null);
+            new SecurityDesc(new DummyJNLPFile(), AppletPermissionLevel.NONE, SecurityDesc.SANDBOX_PERMISSIONS, null);
         } catch (Exception ex) {
             t = ex;
         }
@@ -58,7 +59,7 @@ public class SecurityDescTest {
 
     @Test(expected = NullPointerException.class)
     public void testNullJnlpFile() throws Exception {
-        new SecurityDesc(null, SecurityDesc.SANDBOX_PERMISSIONS, null);
+        new SecurityDesc(null, AppletPermissionLevel.NONE, SecurityDesc.SANDBOX_PERMISSIONS, null);
     }
 
     @Test

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/testing/mock/DummyJNLPFile.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/testing/mock/DummyJNLPFile.java
@@ -36,11 +36,13 @@ exception statement from your version.
  */
 package net.adoptopenjdk.icedteaweb.testing.mock;
 
+import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.sourceforge.jnlp.JNLPFile;
+
 import java.net.URL;
 import java.util.Locale;
-import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
-import net.sourceforge.jnlp.JNLPFile;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
 
 
 public class DummyJNLPFile extends JNLPFile {
@@ -59,7 +61,7 @@ public class DummyJNLPFile extends JNLPFile {
     }
 
     {
-        this.security = new SecurityDesc(this, SecurityDesc.SANDBOX_PERMISSIONS, null);
+        this.security = new SecurityDesc(this, AppletPermissionLevel.NONE, SecurityDesc.SANDBOX_PERMISSIONS, null);
     }
 
     @Override

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/testing/mock/DummyJNLPFileWithJar.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/testing/mock/DummyJNLPFileWithJar.java
@@ -1,17 +1,19 @@
 package net.adoptopenjdk.icedteaweb.testing.mock;
 
+import net.adoptopenjdk.icedteaweb.jnlp.element.information.InformationDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.version.Version;
+import net.sourceforge.jnlp.JNLPFile;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import net.adoptopenjdk.icedteaweb.jnlp.element.information.InformationDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.version.Version;
-import net.sourceforge.jnlp.JNLPFile;
 
 /* A mocked dummy JNLP file with a single JAR. */
 public class DummyJNLPFileWithJar extends JNLPFile {
@@ -54,7 +56,7 @@ public class DummyJNLPFileWithJar extends JNLPFile {
 
         }
         info = new ArrayList<>();
-        this.security = new SecurityDesc(this, SecurityDesc.SANDBOX_PERMISSIONS, null);
+        this.security = new SecurityDesc(this, AppletPermissionLevel.NONE, SecurityDesc.SANDBOX_PERMISSIONS, null);
     }
 
     public URL getJarLocation() {

--- a/core/src/test/java/net/sourceforge/jnlp/JNLPFileTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/JNLPFileTest.java
@@ -38,7 +38,7 @@ exception statement from your version.
 package net.sourceforge.jnlp;
 
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.ApplicationPermissionLevel;
 import net.adoptopenjdk.icedteaweb.testing.annotations.Bug;
 import net.adoptopenjdk.icedteaweb.testing.mock.MockJNLPFile;
 import net.adoptopenjdk.icedteaweb.xmlparser.ParseException;
@@ -245,17 +245,17 @@ public class JNLPFileTest extends NoStdOutErrTest{
         URL codeBase = new URL("http://icedtea.classpath.org");
         InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
         JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.NONE, jnlpFile.getRequestedPermissionLevel());
+        Assert.assertEquals(ApplicationPermissionLevel.NONE, jnlpFile.getApplicationPermissionLevel());
     }
 
     @Test
     public void testGetRequestedPermissionLevel2() throws MalformedURLException, ParseException {
-        String jnlpContents = minimalJnlp.replace("SECURITY", "<security><"+SecurityDesc.RequestedPermissionLevel.ALL.toJnlpString()+"/></security>");
+        String jnlpContents = minimalJnlp.replace("SECURITY", "<security><"+ ApplicationPermissionLevel.ALL.getValue()+"/></security>");
 
         URL codeBase = new URL("http://icedtea.classpath.org");
         InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
         JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.ALL, jnlpFile.getRequestedPermissionLevel());
+        Assert.assertEquals(ApplicationPermissionLevel.ALL, jnlpFile.getApplicationPermissionLevel());
     }
 
     @Test
@@ -265,49 +265,27 @@ public class JNLPFileTest extends NoStdOutErrTest{
         URL codeBase = new URL("http://icedtea.classpath.org");
         InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
         JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.NONE, jnlpFile.getRequestedPermissionLevel());
+        Assert.assertEquals(ApplicationPermissionLevel.NONE, jnlpFile.getApplicationPermissionLevel());
     }
 
     @Test
     public void testGetRequestedPermissionLevel4() throws MalformedURLException, ParseException {
-        String jnlpContents = minimalJnlp.replace("SECURITY", "<security>whatever</security>");
+        String jnlpContents = minimalJnlp.replace("SECURITY", "<security>unknown</security>");
 
         URL codeBase = new URL("http://icedtea.classpath.org");
         InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
         JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.NONE, jnlpFile.getRequestedPermissionLevel());
+        Assert.assertEquals(ApplicationPermissionLevel.NONE, jnlpFile.getApplicationPermissionLevel());
     }
     
     @Test
     public void testGetRequestedPermissionLevel5() throws MalformedURLException, ParseException {
-        String jnlpContents = minimalJnlp.replace("SECURITY", "<security><"+SecurityDesc.RequestedPermissionLevel.J2EE.toJnlpString()+"/></security>");
+        String jnlpContents = minimalJnlp.replace("SECURITY", "<security><"+ ApplicationPermissionLevel.J2EE.getValue()+"/></security>");
 
         URL codeBase = new URL("http://icedtea.classpath.org");
         InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
         JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.J2EE, jnlpFile.getRequestedPermissionLevel());
-    }
-    
-    @Test
-    //unknown for jnlp
-    public void testGetRequestedPermissionLevel6() throws MalformedURLException, ParseException {
-        String jnlpContents = minimalJnlp.replace("SECURITY", "<security><" + SecurityDesc.RequestedPermissionLevel.SANDBOX.toHtmlString() + "/></security>");
-
-        URL codeBase = new URL("http://icedtea.classpath.org");
-        InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
-        JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.NONE, jnlpFile.getRequestedPermissionLevel());
-    }
-    
-    @Test
-    //unknown for jnlp
-    public void testGetRequestedPermissionLevel7() throws MalformedURLException, ParseException {
-        String jnlpContents = minimalJnlp.replace("SECURITY", "<security><" + SecurityDesc.RequestedPermissionLevel.DEFAULT.toHtmlString() + "/></security>");
-
-        URL codeBase = new URL("http://icedtea.classpath.org");
-        InputStream is = new ByteArrayInputStream(jnlpContents.getBytes());
-        JNLPFile jnlpFile = new JNLPFile(is, codeBase, new ParserSettings(false, false, false));
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.NONE, jnlpFile.getRequestedPermissionLevel());
+        Assert.assertEquals(ApplicationPermissionLevel.J2EE, jnlpFile.getApplicationPermissionLevel());
     }
     
     @Test

--- a/core/src/test/java/net/sourceforge/jnlp/PluginBridgeTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/PluginBridgeTest.java
@@ -26,7 +26,7 @@ import net.adoptopenjdk.icedteaweb.io.IOUtils;
 import net.adoptopenjdk.icedteaweb.jnlp.element.application.AppletDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.ResourcesDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.version.Version;
 import net.adoptopenjdk.icedteaweb.xmlparser.ParseException;
 import net.sourceforge.jnlp.cache.CacheUtil;
@@ -145,24 +145,19 @@ public class PluginBridgeTest extends NoStdOutErrTest{
         params.put("jnlp_href", relativeLocation);
         MockJnlpFileFactory mockCreator = new MockJnlpFileFactory();
         PluginBridge pb = new PluginBridge(codeBase, null, "", "", 0, 0, params, mockCreator);
-        assertEquals(pb.getRequestedPermissionLevel(), SecurityDesc.RequestedPermissionLevel.NONE);
+        assertEquals(pb.getAppletPermissionLevel(), AppletPermissionLevel.NONE);
         
-        params.put(SecurityDesc.RequestedPermissionLevel.PERMISSIONS_NAME,SecurityDesc.RequestedPermissionLevel.ALL.toHtmlString());
+        params.put(PluginBridge.PERMISSIONS_NAME, AppletPermissionLevel.ALL.getValue());
         pb = new PluginBridge(codeBase, null, "", "", 0, 0, params, mockCreator);
-        assertEquals(pb.getRequestedPermissionLevel(), SecurityDesc.RequestedPermissionLevel.ALL);
+        assertEquals(pb.getAppletPermissionLevel(), AppletPermissionLevel.ALL);
         
-        //unknown for applets!
-        params.put(SecurityDesc.RequestedPermissionLevel.PERMISSIONS_NAME, SecurityDesc.RequestedPermissionLevel.J2EE.toJnlpString());
+        params.put(PluginBridge.PERMISSIONS_NAME, AppletPermissionLevel.SANDBOX.getValue());
         pb = new PluginBridge(codeBase, null, "", "", 0, 0, params, mockCreator);
-        assertEquals(pb.getRequestedPermissionLevel(), SecurityDesc.RequestedPermissionLevel.NONE);
+        assertEquals(pb.getAppletPermissionLevel(), AppletPermissionLevel.SANDBOX);
         
-        params.put(SecurityDesc.RequestedPermissionLevel.PERMISSIONS_NAME, SecurityDesc.RequestedPermissionLevel.SANDBOX.toHtmlString());
+        params.put(PluginBridge.PERMISSIONS_NAME, AppletPermissionLevel.DEFAULT.getValue());
         pb = new PluginBridge(codeBase, null, "", "", 0, 0, params, mockCreator);
-        assertEquals(pb.getRequestedPermissionLevel(), SecurityDesc.RequestedPermissionLevel.SANDBOX);
-        
-        params.put(SecurityDesc.RequestedPermissionLevel.PERMISSIONS_NAME, SecurityDesc.RequestedPermissionLevel.DEFAULT.toHtmlString());
-        pb = new PluginBridge(codeBase, null, "", "", 0, 0, params, mockCreator);
-        assertEquals(pb.getRequestedPermissionLevel(), SecurityDesc.RequestedPermissionLevel.NONE);
+        assertEquals(pb.getAppletPermissionLevel(), AppletPermissionLevel.NONE);
     }
 
     @Test

--- a/core/src/test/java/net/sourceforge/jnlp/runtime/CodeBaseClassLoaderTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/runtime/CodeBaseClassLoaderTest.java
@@ -38,6 +38,7 @@ package net.sourceforge.jnlp.runtime;
 
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendedsecurity.AppletSecurityLevel;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendedsecurity.AppletStartupSecuritySettings;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
 import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
 import net.adoptopenjdk.icedteaweb.testing.ServerAccess;
 import net.adoptopenjdk.icedteaweb.testing.annotations.Bug;
@@ -265,7 +266,7 @@ public class CodeBaseClassLoaderTest extends NoStdOutErrTest {
         JNLPFile dummyJnlpFile = new DummyJNLPFile() {
             @Override
             public SecurityDesc getSecurity() {
-                return new SecurityDesc(null, SecurityDesc.SANDBOX_PERMISSIONS, null);
+                return new SecurityDesc(null, AppletPermissionLevel.NONE, SecurityDesc.SANDBOX_PERMISSIONS, null);
             }
         };
         JNLPClassLoader parent = new JNLPClassLoader(dummyJnlpFile, null);

--- a/core/src/test/java/net/sourceforge/jnlp/runtime/JNLPFileTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/runtime/JNLPFileTest.java
@@ -39,7 +39,7 @@ package net.sourceforge.jnlp.runtime;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendedsecurity.AppletSecurityLevel;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendedsecurity.AppletStartupSecuritySettings;
 import net.adoptopenjdk.icedteaweb.jnlp.element.information.InformationDesc;
-import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
 import net.adoptopenjdk.icedteaweb.testing.mock.DummyJNLPFileWithJar;
 import net.adoptopenjdk.icedteaweb.testing.util.FileTestUtils;
 import net.sourceforge.jnlp.JNLPFile;
@@ -195,7 +195,7 @@ public class JNLPFileTest extends NoStdOutErrTest {
         Assert.assertEquals("*.net  ftp://*uu.co.uk", jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.CALLER_ALLOWABLE)));
         Assert.assertEquals("*.com *.net *.cz *.co.uk", jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.CODEBASE)));
         // Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.SANDBOX.toHtmlString(), jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.PERMISSIONS))); /* commented due to DummyJNLP being "signed" */
-        Assert.assertEquals(SecurityDesc.RequestedPermissionLevel.ALL.toHtmlString(), jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.PERMISSIONS)));
+        Assert.assertEquals(AppletPermissionLevel.ALL.getValue(), jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.PERMISSIONS)));
         Assert.assertEquals("false", jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.TRUSTED_LIBRARY)));
         Assert.assertEquals("false", jnlpFile.getManifestsAttributes().getAttribute(new Attributes.Name(JNLPFile.ManifestsAttributes.TRUSTED_ONLY)));
 


### PR DESCRIPTION
- split RequestedPermissionLevel by AppletPermissionLevel and ApplicationPermissionLevel to better reflect JSR spec and entangle applet/html from application/jnlp logic
- improved documentation