### PR TITLE
fix translation bug that inverted the meaning

### DIFF
--- a/common/src/main/resources/net/adoptopenjdk/icedteaweb/i18n/Messages_de.properties
+++ b/common/src/main/resources/net/adoptopenjdk/icedteaweb/i18n/Messages_de.properties
@@ -183,7 +183,7 @@ LAskToContinue=Soll die Ausf\u00fchrung dieser Anwendung dennoch fortgesetzt wer
 # Parser
 PInvalidRoot=Der Wurzelknoten ist nicht das Element jnlp
 PNoResources=Kein Element resources angeben
-PUntrustedNative=Das Element nativelib kann nicht angegeben werden sofern eine vertrauensw\u00fcrdige Umgebung angefordert wird.
+PUntrustedNative=Das Element nativelib kann nur angegeben werden, wenn eine vertrauensw\u00fcrdige Umgebung angefordert wird.
 PExtensionHasJ2SE=Das Element j2se kann nicht in einer Komponentenerweiterungsdatei angegeben werden.
 PInnerJ2SE=Das Element j2se kann nicht innerhalb eines j2se-Elements angegeben werden.
 PTwoMains=Doppeltes main JAR in einem resources-Element definiert (es kann nur eins geben)


### PR DESCRIPTION
- German translation for PUntrustedNative has the opposite meaning of the English text 
- fixed and used a positive wording instead of two times negative