### PR TITLE
Added embedded mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,8 +111,8 @@ AC_SUBST(ITW_LIBS)
 if test x"$ITW_LIBS" = xnone -o x"$ITW_LIBS" = x; then
     AC_MSG_ERROR([missing --with-itw-libs; mandatory on linux. Use BUNDLED, DISTRIBUTION or BOTH. use BOTH with care. ])
 fi
-if test ! "$ITW_LIBS" = BUNDLED -a ! "$ITW_LIBS" = DISTRIBUTION -a ! "$ITW_LIBS" = BOTH; then
-    AC_MSG_ERROR([incorrect --with-itw-libs; mandatory are BUNDLED, DISTRIBUTION or BOTH ])
+if test ! "$ITW_LIBS" = BUNDLED -a ! "$ITW_LIBS" = DISTRIBUTION -a ! "$ITW_LIBS" = EMBEDDED; then
+    AC_MSG_ERROR([incorrect --with-itw-libs; mandatory are BUNDLED, DISTRIBUTION or EMBEDDED ])
 fi
 
 IT_CHECK_WITH_GCJ

--- a/rust-launcher/src/hardcoded_paths.rs
+++ b/rust-launcher/src/hardcoded_paths.rs
@@ -90,7 +90,7 @@ fn sanitize(candidate: Option<&'static str>)  -> Option<&'static str> {
 pub enum ItwLibSearch {
     BUNDLED,
     DISTRIBUTION,
-    BOTH,
+    EMBEDDED //like BUNDLED, but with affect on jre path
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -101,8 +101,8 @@ impl FromStr for ItwLibSearch {
     type Err = ParseItwLibSearch;
 
     fn from_str(sstr: &str) -> Result<ItwLibSearch, ParseItwLibSearch> {
-        if sstr == "BOTH" {
-            return Ok(ItwLibSearch::BOTH);
+        if sstr == "EMBEDDED" {
+            return Ok(ItwLibSearch::EMBEDDED);
         }
         if sstr == "BUNDLED" {
             return Ok(ItwLibSearch::BUNDLED);
@@ -111,6 +111,16 @@ impl FromStr for ItwLibSearch {
             return Ok(ItwLibSearch::DISTRIBUTION);
         }
         return Err(ParseItwLibSearch { _priv: () })
+    }
+}
+
+impl std::fmt::Display for ItwLibSearch {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ItwLibSearch::BUNDLED => write!(f, "BUNDLED"),
+            ItwLibSearch::DISTRIBUTION => write!(f, "DISTRIBUTION"),
+            ItwLibSearch::EMBEDDED => write!(f, "EMBEDDED"),
+        }
     }
 }
 
@@ -123,7 +133,7 @@ pub fn get_libsearch(logger: &os_access::Os) -> ItwLibSearch {
             }
             _err => {
                 let mut info = String::new();
-                write!(&mut info, "ITW-LIBS provided, but have invalid value of {}. Use BUNDLED, DISTRIBUTION or BOTH", result_of_override_var);
+                write!(&mut info, "ITW-LIBS provided, but have invalid value of {}. Use BUNDLED, DISTRIBUTION or EMBEDDED", result_of_override_var);
                 logger.important(&info);
             }
         }
@@ -177,13 +187,13 @@ mod tests {
 
     #[test]
     fn get_itwlibsearch_in_enumeration() {
-        assert_eq!(super::get_itwlibsearch() == "BOTH" || super::get_itwlibsearch() == "BUNDLED" || super::get_itwlibsearch() == "DISTRIBUTION", true);
+        assert_eq!(super::get_itwlibsearch() == "EMBEDDED" || super::get_itwlibsearch() == "BUNDLED" || super::get_itwlibsearch() == "DISTRIBUTION", true);
     }
 
     #[test]
     fn itw_libsearch_to_enum_test() {
         assert!(super::ItwLibSearch::from_str("BUNDLED") == Ok(super::ItwLibSearch::BUNDLED));
-        assert!(super::ItwLibSearch::from_str("BOTH") == Ok(super::ItwLibSearch::BOTH));
+        assert!(super::ItwLibSearch::from_str("EMBEDDED") == Ok(super::ItwLibSearch::EMBEDDED));
         assert!(super::ItwLibSearch::from_str("DISTRIBUTION") == Ok(super::ItwLibSearch::DISTRIBUTION));
         assert!(super::ItwLibSearch::from_str("") == Err(super::ParseItwLibSearch { _priv: () }));
     }

--- a/rust-launcher/src/jars_helper.rs
+++ b/rust-launcher/src/jars_helper.rs
@@ -8,6 +8,7 @@ use dirs_paths_helper;
 use std::fmt::Write;
 
 //order important!
+// TODO verify with EMBEDDED
 const LOCAL_PATHS: &'static [&'static str] = &[
     "share/icedtea-web",
     "linux-deps-runtime",
@@ -86,7 +87,7 @@ fn resolve_jar(full_hardcoded_path: &str, logger: &os_access::Os) -> std::path::
         }
     }
     //first local dir - if allowed
-    if current_libsearch == ItwLibSearch::BUNDLED || current_libsearch == ItwLibSearch::BOTH {
+    if current_libsearch == ItwLibSearch::BUNDLED || current_libsearch == ItwLibSearch::EMBEDDED {
         let pgmdir = dirs_paths_helper::current_program_parent();
         let pgmparent: std::path::PathBuf = match pgmdir.parent() {
             Some(s) => {
@@ -106,7 +107,7 @@ fn resolve_jar(full_hardcoded_path: &str, logger: &os_access::Os) -> std::path::
         }
     }
     //then installed dirs, if allowd
-    if current_libsearch == ItwLibSearch::DISTRIBUTION || current_libsearch == ItwLibSearch::BOTH {
+    if current_libsearch == ItwLibSearch::DISTRIBUTION {
         let candidate = std::path::PathBuf::from(full_hardcoded_path);
         if dirs_paths_helper::is_file(&candidate) {
             logger.log(&dirs_paths_helper::path_to_string(&candidate));
@@ -224,10 +225,9 @@ pub fn get_bootclasspath(jre_path: &std::path::PathBuf, os: &os_access::Os) -> S
 #[cfg(test)]
 mod tests {
     use utils::tests_utils as tu;
-    use std::path::PathBuf;
 
     #[test]
-    fn compose_class_path_test_emty() {
+    fn compose_class_path_test_empty() {
         assert_eq!("", super::compose_class_path(vec![], &tu::TestLogger::create_new()));
     }
 

--- a/rust-launcher/src/log_helper.rs
+++ b/rust-launcher/src/log_helper.rs
@@ -76,7 +76,7 @@ impl Default for AdvancedLogging {
     fn default() -> AdvancedLogging {
         AdvancedLogging {
             log_to_file: false,
-            log_target_file: std::path::PathBuf::from("undeffined"),
+            log_target_file: std::path::PathBuf::from("undefined"),
             log_to_stdstreams: true,
             log_to_system: true,
         }

--- a/rust-launcher/src/main.rs
+++ b/rust-launcher/src/main.rs
@@ -92,6 +92,9 @@ fn main() {
         os = get_os(is_debug_on(), true);
     }
     os.log(&dirs_paths_helper::path_to_string(&dirs_paths_helper::current_program()));
+    let mut info1 = String::new();
+    write!(&mut info1, "itw-rust-debug: itw mode: {}", hardcoded_paths::get_libsearch(&os)).expect("unwrap failed");
+    os.log(&info1);
     let java_dir = utils::find_jre(&os);
     let mut info2 = String::new();
     write!(&mut info2, "selected jre: {}", java_dir.display()).expect("unwrap failed");
@@ -137,7 +140,7 @@ fn compose_arguments(java_dir: &std::path::PathBuf, original_args: &std::vec::Ve
 
     let mut bin_name = String::from("-Dicedtea-web.bin.name=");
     let mut bin_location = String::from("-Dicedtea-web.bin.location=");
-    //no metter what ITW_LIBS are saying, imho using current pgm is always correct comapred to hardcoded values
+    //no matter what ITW_LIBS are saying, imho using current pgm is always correct comapred to hardcoded values
     bin_name.push_str(&current_name);
     bin_location.push_str(&dirs_paths_helper::path_to_string(&current_bin));
 

--- a/rust-launcher/src/property_from_file.rs
+++ b/rust-launcher/src/property_from_file.rs
@@ -33,7 +33,7 @@ impl Validator for JreValidator {
     fn get_fail_message(&self, key: &str, value: &str, file: &Option<std::path::PathBuf>) -> String {
         let mut res = String::new();
         write!(&mut res, "Your custom JRE {} read from {} under key {} is not valid.", value, file.clone().expect("jre path should be loaded").display(), key).expect("unwrap failed");
-        write!(&mut res, " Trying other config files, then using default ({}, {}, registry or JAVA_HOME) in attempt to start. Please fix this.", hardcoded_paths::get_java(), hardcoded_paths::get_jre()).expect("unwrap failed");
+        write!(&mut res, " Trying other config files, then using default ({}, {}, registry or JAVA_HOME) in attempt to start. Please fix this.", hardcoded_paths::get_jre(), hardcoded_paths::get_jre()).expect("unwrap failed");
         return res;
     }
 }

--- a/rust-launcher/src/utils.rs
+++ b/rust-launcher/src/utils.rs
@@ -33,7 +33,32 @@ pub fn find_jre(os: &os_access::Os) -> std::path::PathBuf {
                     return java_home;
                 }
                 Err(_e) => {
-                    os.log("itw-rust-debug: nothing");
+                    os.log("itw-rust-debug: nothing (likely correct)");
+                    if hardcoded_paths::get_libsearch(os) == hardcoded_paths::ItwLibSearch::EMBEDDED {
+                        os.log("itw-rust-debug: trying embedded JDK");
+                        let mut embed_path1 = dirs_paths_helper::current_program_parent().clone();
+                        embed_path1.push("..");
+                        let mut embed_java = embed_path1.clone();
+                        embed_java.push("bin");
+                        embed_java.push("java");
+                        if embed_java.exists() {
+                            os.log("itw-rust-debug: found and using");
+                            return embed_path1;
+                        }
+                        let mut embed_path2 = dirs_paths_helper::current_program_parent().clone();
+                        embed_path2.push("..");
+                        embed_path2.push("..");
+                        embed_java = embed_path2.clone();
+                        embed_java.push("bin");
+                        embed_java.push("java");
+                        if embed_java.exists() {
+                            os.log("itw-rust-debug: found and using");
+                            return embed_path2;
+                        }
+                        let mut info1 = String::new();
+                        write!(&mut info1, "You have EMBEDDED jre build, however {}  nor {} is valid jre/jdk!", embed_path1.to_str().expect("unwrap failed"), embed_path2.to_str().expect("unwrap failed")).expect("unwrap failed");
+                        os.important(&info1);
+                    }
                     os.log("itw-rust-debug: trying jdk from registry");
                     match os.get_registry_java() {
                         Some(path) => {
@@ -77,8 +102,8 @@ fn get_jdk_from_path_conditionally_testable(system_path: Option<OsString>, libse
         os.log("itw-rust-debug: skipping jdk from path, your build is distribution");
         None
     } else {
-        if libsearch == hardcoded_paths::ItwLibSearch::BOTH {
-            os.important("your build is done as BOTH distribution and bundled, jdk from PATH may be not what you want!");
+        if libsearch == hardcoded_paths::ItwLibSearch::EMBEDDED {
+            os.important("your build is done as EMBEDDED, jdk from PATH may be not what you want!");
         }
         get_jdk_from_given_path_testable(system_path, os)
     }
@@ -160,13 +185,13 @@ pub mod tests_utils {
                    None);
         assert_eq!(super::get_jdk_from_path_conditionally_testable(None, hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new()),
                    None);
-        assert_eq!(super::get_jdk_from_path_conditionally_testable(None, hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new()),
+        assert_eq!(super::get_jdk_from_path_conditionally_testable(None, hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new()),
                    None);
         assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new()),
                    None);
         assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new()),
                    None);
-        assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new()),
+        assert_eq!(super::get_jdk_from_path_conditionally_testable(Some(fo::from("/some/bad/path")), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new()),
                    None);
     }
 
@@ -177,7 +202,7 @@ pub mod tests_utils {
         master_dir.push("bin");
         let v1 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new());
         let v2 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new());
-        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new());
+        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new());
         debuggable_remove_dir(&master_dir);
         assert_eq!(None, v1);
         assert_eq!(Some(top_dir.clone()), v2);
@@ -189,7 +214,7 @@ pub mod tests_utils {
         let master_dir = fake_jre(false);
         let v1 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new());
         let v2 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new());
-        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new());
+        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new());
         debuggable_remove_dir(&master_dir);
         assert_eq!(None, v1);
         assert_eq!(None, v2);
@@ -206,7 +231,7 @@ pub mod tests_utils {
         File::create(&fake_jre).expect("File created");
         let v1 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::DISTRIBUTION, &TestLogger::create_new());
         let v2 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BUNDLED, &TestLogger::create_new());
-        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::BOTH, &TestLogger::create_new());
+        let v3 = super::get_jdk_from_path_conditionally_testable(Some(fo::from(master_dir.clone())), hardcoded_paths::ItwLibSearch::EMBEDDED, &TestLogger::create_new());
         debuggable_remove_dir(&master_dir);
         assert_eq!(None, v1);
         let parent = dirs_paths_helper::canonicalize(&std::path::PathBuf::from(master_dir.parent().expect("just created"))).expect("canonicalize failed");


### PR DESCRIPTION
If itw is built in EMBEDDED mode, then it search for jre/jdk "where it is placed" right after java_home.
It is done by simple .., ../..
The search for libraries is then done in same way as for BUNDLED mode