### PR TITLE
Forced recognition of system jars

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPPolicy.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPPolicy.java
@@ -178,9 +178,8 @@ public class JNLPPolicy extends Policy {
         }
         
         // check to see if source protocol is a Java System Library protocol
-        if (sourceProtocol.equalsIgnoreCase("jrt"))
-        {
-            // jrt protocls are only for system code return true 
+        if (sourceProtocol.equalsIgnoreCase("jrt")) {
+            // jrt protocols are only for system code return true 
             return true; 
         }        
         

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPPolicy.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPPolicy.java
@@ -176,7 +176,14 @@ public class JNLPPolicy extends Policy {
                 sourcePath.startsWith(jreExtDir.getRawPath())) {
             return true;
         }
-
+        
+        // check to see if source protocol is a Java System Library protocol
+        if (sourceProtocol.equalsIgnoreCase("jrt"))
+        {
+            // jrt protocls are only for system code return true 
+            return true; 
+        }        
+        
         return false;
     }
 


### PR DESCRIPTION
Attempting to use built in java security packages when running java web start applications results in permission denials.  These permission denials occur upon initialization of the packages for sun security such as mscapi and jgss.    Even though an application has been allowed to run with all permissions, these packages were being denied runtime and security permissions.   Output for these denials are shown below: 

Denying permission: ("java.lang.RuntimePermission" "accessClassInPackage.sun.security.util")
Denying permission: ("java.security.SecurityPermission" "putProviderProperty.XMLDSig")
Denying permission: ("java.lang.RuntimePermission" "accessClassInPackage.sun.security.util")
Denying permission: ("java.lang.RuntimePermission" "accessClassInPackage.sun.security.util")
Denying permission: ("java.lang.RuntimePermission" "accessClassInPackage.sun.security.util")
Denying permission: ("java.lang.RuntimePermission"  "loadLibrary.sunmscapi")
Denying permission: ("java.util.PropertyPermission"  "sun.security.jgss.native" "read")