### PR TITLE
fix(ManifestAttributesChecker): jars must be relative to codebase

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/manifest/ManifestAttributesChecker.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/manifest/ManifestAttributesChecker.java
@@ -390,8 +390,8 @@ public class ManifestAttributesChecker {
 
         boolean allOk = true;
         for (URL u : usedUrls) {
-            if (UrlUtils.equalsIgnoreLastSlash(u, codebase)
-                    && UrlUtils.equalsIgnoreLastSlash(u, stripDocbase(documentBase))) {
+            if (UrlUtils.urlRelativeTo(u, codebase)
+                    && UrlUtils.urlRelativeTo(u, stripDocbase(documentBase))) {
                 LOG.debug("OK - {} is from codebase/docbase.", u.toExternalForm());
             } else {
                 allOk = false;

--- a/core/src/main/java/net/sourceforge/jnlp/util/UrlUtils.java
+++ b/core/src/main/java/net/sourceforge/jnlp/util/UrlUtils.java
@@ -272,32 +272,6 @@ public class UrlUtils {
         return s;
     }
 
-    /**
-     * both urls are processed by sanitizeLastSlash before actual equals. So
-     * protocol://som.url/some/path/ is same as protocol://som.url/some/path. Even
-     * protocol://som.url/some/path\ is same as protocol://som.url/some/path/
-     *
-     * @param u1 first url to compare
-     * @param u2 second
-     * @return true if urls are equals no matter of trailing slash
-     */
-    public static boolean equalsIgnoreLastSlash(final URL u1, final URL u2) {
-        try {
-            if (u1 == null && u2 == null) {
-                return true;
-            }
-            if (u1 == null && u2 != null) {
-                return false;
-            }
-            if (u1 != null && u2 == null) {
-                return false;
-            }
-            return Objects.equals(sanitizeLastSlash(u1), sanitizeLastSlash(u2));
-        } catch (final MalformedURLException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
     public static URL guessCodeBase(final JNLPFile file) {
         if (file.getCodeBase() != null) {
             return file.getCodeBase();
@@ -338,6 +312,45 @@ public class UrlUtils {
             }
         } catch (Exception ex) {
             LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, ex);
+        }
+        return false;
+    }
+    /**
+     * Checks whether <code>url</code> is relative (or equal) to <code>codebaseUrl</code>.
+     * both urls are processed by sanitizeLastSlash before actual equals. So
+     * protocol://som.url/some/path/ is same as protocol://som.url/some/path. Even
+     * protocol://som.url/some/path\ is same as protocol://som.url/some/path/
+     *
+     * This method returns false in case <code>url</code> contains parent directory notation "..".
+     * See JNLP specification version 9, 3.4: 'A relative URL cannot contain parent directory notations, such as "..". It must denote a file that is stored in a subdirectory of the codebase.'
+     * @param url the url to check
+     * @param codebaseUrl the url to check against
+     * @return true if <code>url</code> is relative to <code>codebaseUrl</code>
+     */
+    public static boolean urlRelativeTo(URL url, URL codebaseUrl) {
+        if (codebaseUrl == url) {
+            return true;
+        }
+        if (codebaseUrl == null || url == null) {
+            return false;
+        }
+        try {
+            URL nu = sanitizeLastSlash(normalizeUrl(url));
+            URL nup = sanitizeLastSlash(normalizeUrl(codebaseUrl));
+            if (!getHostAndPort(nu).equals(getHostAndPort(nup))) {
+                return false;
+            }
+            if (!nu.getProtocol().equals(nup.getProtocol())) {
+                return false;
+            }
+            if (nu.getPath().contains("..")) {
+                return false;
+            }
+            if (nu.getPath().startsWith(nup.getPath())) {
+                return true;
+            }
+        } catch (MalformedURLException | UnsupportedEncodingException | URISyntaxException e) {
+            LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
         }
         return false;
     }

--- a/core/src/main/java/net/sourceforge/jnlp/util/UrlUtils.java
+++ b/core/src/main/java/net/sourceforge/jnlp/util/UrlUtils.java
@@ -81,6 +81,7 @@ public class UrlUtils {
     public static final String BACKSLASH_REGEX = "\\?";
     public static final String HTTPS = "https";
     public static final String BACKSLASH_N = "\n";
+    public static final String PARENT_DIR = "..";
 
     public static URL normalizeUrlAndStripParams(final URL url, final boolean encodeFileUrls) {
         if (url == null) {
@@ -327,7 +328,7 @@ public class UrlUtils {
      * @param codebaseUrl the url to check against
      * @return true if <code>url</code> is relative to <code>codebaseUrl</code>
      */
-    public static boolean urlRelativeTo(URL url, URL codebaseUrl) {
+    public static boolean urlRelativeTo(final URL url, final URL codebaseUrl) {
         if (codebaseUrl == url) {
             return true;
         }
@@ -335,18 +336,18 @@ public class UrlUtils {
             return false;
         }
         try {
-            URL nu = sanitizeLastSlash(normalizeUrl(url));
-            URL nup = sanitizeLastSlash(normalizeUrl(codebaseUrl));
-            if (!getHostAndPort(nu).equals(getHostAndPort(nup))) {
+            final URL sanUrl = sanitizeLastSlash(normalizeUrl(url));
+            final URL sanCodebase = sanitizeLastSlash(normalizeUrl(codebaseUrl));
+            if (!getHostAndPort(sanUrl).equals(getHostAndPort(sanCodebase))) {
                 return false;
             }
-            if (!nu.getProtocol().equals(nup.getProtocol())) {
+            if (!sanUrl.getProtocol().equals(sanCodebase.getProtocol())) {
                 return false;
             }
-            if (nu.getPath().contains("..")) {
+            if (sanUrl.getPath().contains(PARENT_DIR)) {
                 return false;
             }
-            if (nu.getPath().startsWith(nup.getPath())) {
+            if (sanUrl.getPath().startsWith(sanCodebase.getPath())) {
                 return true;
             }
         } catch (MalformedURLException | UnsupportedEncodingException | URISyntaxException e) {

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/manifest/ManifestAttributesCheckerTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/manifest/ManifestAttributesCheckerTest.java
@@ -36,6 +36,15 @@
  */
 package net.adoptopenjdk.icedteaweb.manifest;
 
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.AppletPermissionLevel;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.adoptopenjdk.icedteaweb.testing.mock.DummyJNLPFileWithJar;
+import net.sourceforge.jnlp.JNLPFile;
+import net.sourceforge.jnlp.LaunchException;
+import net.sourceforge.jnlp.config.ConfigurationConstants;
+import net.sourceforge.jnlp.runtime.DummySecurityDelegate;
+import net.sourceforge.jnlp.runtime.JNLPClassLoader;
+import net.sourceforge.jnlp.runtime.JNLPRuntime;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,6 +63,20 @@ public class ManifestAttributesCheckerTest {
         tryTest("http://aaa.bb/ccc", "http://aaa.bb/");
         tryTest("http://aaa.bb/", "http://aaa.bb/");
         tryTest("http://aaa.bb", "http://aaa.bb");
+    }
+
+    @Test
+    public void checkAllCheckAlacTest() throws LaunchException, MalformedURLException {
+        // can't check failing cases as ManifestAttributesChecker intertwines logic & GUI
+        URL codebase = new URL("http://aaa/bb/");
+        URL jar1 = new URL("http://aaa/bb/a.jar");
+        URL jar2 = new URL("http://aaa/bb/lib/a.jar");
+        JNLPFile file = new DummyJNLPFileWithJar(codebase, jar1, jar2);
+        SecurityDesc security = new SecurityDesc(file, AppletPermissionLevel.ALL,SecurityDesc.ALL_PERMISSIONS, codebase);
+        JNLPClassLoader.SecurityDelegate securityDelegate = new DummySecurityDelegate();
+        ManifestAttributesChecker checker = new ManifestAttributesChecker(security, file, JNLPClassLoader.SigningState.FULL, securityDelegate);
+        JNLPRuntime.getConfiguration().setProperty(ConfigurationConstants.KEY_ENABLE_MANIFEST_ATTRIBUTES_CHECK, ManifestAttributesChecker.MANIFEST_ATTRIBUTES_CHECK.ALAC.name());
+        checker.checkAll();
     }
 
     private static void tryTest(String src, String expected) throws MalformedURLException {

--- a/core/src/test/java/net/sourceforge/jnlp/runtime/DummySecurityDelegate.java
+++ b/core/src/test/java/net/sourceforge/jnlp/runtime/DummySecurityDelegate.java
@@ -1,0 +1,56 @@
+package net.sourceforge.jnlp.runtime;
+
+import java.net.URL;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Collection;
+import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.element.security.SecurityDesc;
+import net.sourceforge.jnlp.LaunchException;
+import net.sourceforge.jnlp.runtime.JNLPClassLoader.SecurityDelegate;
+
+public class DummySecurityDelegate implements SecurityDelegate {
+
+    public boolean isPluginApplet() {
+        return false;
+    }
+
+    public boolean userPromptedForPartialSigning() {
+        return false;
+    }
+
+    public boolean userPromptedForSandbox() {
+        return false;
+    }
+
+    public SecurityDesc getCodebaseSecurityDesc(JARDesc jarDesc, URL codebaseHost) {
+        return null;
+    }
+
+    public SecurityDesc getClassLoaderSecurity(URL codebaseHost) throws LaunchException {
+        return null;
+    }
+
+    public SecurityDesc getJarPermissions(URL codebaseHost) {
+        return null;
+    }
+
+    public void promptUserOnPartialSigning() throws LaunchException {
+    }
+
+    public void setRunInSandbox() throws LaunchException {
+    }
+
+    public boolean getRunInSandbox() {
+        return false;
+    }
+
+    public void addPermission(Permission perm) {
+    }
+
+    public void addPermissions(PermissionCollection perms) {
+    }
+
+    public void addPermissions(Collection<Permission> perms) {
+    }
+}

--- a/core/src/test/java/net/sourceforge/jnlp/util/UrlUtilsTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/util/UrlUtilsTest.java
@@ -171,22 +171,6 @@ public class UrlUtilsTest {
     }
 
     @Test
-    public void testEqualsIgnoreLastSlash() throws Exception {
-        URL u11 = (new URL("http://aa.bb/aaa/bbb////"));
-        URL u22 = (new URL("http://aa.bb/aaa/bbb"));
-        assertTrue(UrlUtils.equalsIgnoreLastSlash(u11, u22));
-        assertTrue(UrlUtils.equalsIgnoreLastSlash(u11, new URL("http://aa.bb/aaa/bbb")));
-
-        URL u1 = (new URL("http://aa.bb/aaa\\bbb\\"));
-        URL u2 = (new URL("http://aa.bb/aaa\\bbb"));
-        assertTrue(UrlUtils.equalsIgnoreLastSlash(u1, u2));
-        assertTrue(UrlUtils.equalsIgnoreLastSlash(u1, new URL("http://aa.bb/aaa\\bbb")));
-
-        assertTrue(UrlUtils.equalsIgnoreLastSlash(new URL("http://aa.bb/aaa\\bbb\\"), new URL("http://aa.bb/aaa\\bbb/")));
-        assertFalse(UrlUtils.equalsIgnoreLastSlash(new URL("http://aa.bb/aaa\\bbb\\"), new URL("http://aa.bb/aaa/bbb/")));
-    }
-
-    @Test
     public void removeFileName1() throws Exception {
         URL l1 = UrlUtils.removeFileName(new URL("http://aaa.bb/xyz/hchkr/jar.jar"));
         assertEquals(l1, new URL("http://aaa.bb/xyz/hchkr"));
@@ -413,5 +397,21 @@ public class UrlUtilsTest {
     public void ensureSlashTailTest3() throws MalformedURLException {
         Assert.assertEquals("http://aa.bb:2/aa/", UrlUtils.ensureSlashTail(new URL("http://aa.bb:2/aa")).toExternalForm());
         Assert.assertEquals("http://aa.bb/aa/", UrlUtils.ensureSlashTail(new URL("http://aa.bb/aa/")).toExternalForm());
+    }
+
+    @Test
+    public void urlIsChildTest() throws MalformedURLException {
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a/"), new URL("http://a/")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a/"), new URL("http://a")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a"), new URL("http://a/")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a////"), new URL("http://a/")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://aa.bb/aaa\\bbb\\"),new URL("http://aa.bb/aaa\\bbb")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://aa.bb/aaa\\bbb\\"), new URL("http://aa.bb/aaa\\bbb/")));
+        assertFalse(UrlUtils.urlRelativeTo(new URL("http://aa.bb/aaa\\bbb\\"), new URL("http://aa.bb/aaa/bbb/")));
+        assertFalse(UrlUtils.urlRelativeTo(new URL("http://a/b/../c.jar"), new URL("http://a/b/")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a/c.jar"), new URL("http://a/")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a/b/c.jar"), new URL("http://a/")));
+        assertTrue(UrlUtils.urlRelativeTo(new URL("http://a/b/d/c.jar"), new URL("http://a/b")));
+        assertFalse(UrlUtils.urlRelativeTo(new URL("http://a/b/c.jar"), new URL("https://a/")));
     }
 }


### PR DESCRIPTION
Closes #256

I have created class DummySecurityDelegate as it seems that neither Mockito nor Easymock is used and I didn't want to introduce dependencies. Will happily do if required.