### PR TITLE
BUGFix: handle spaces in path names

### DIFF
--- a/launchers/shell-launcher/launchers.sh.in
+++ b/launchers/shell-launcher/launchers.sh.in
@@ -45,7 +45,7 @@ while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer 
   [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
 done
 readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
-readonly PORTABLE_ITW_HOME="`dirname $SCRIPT_DIR`"
+readonly PORTABLE_ITW_HOME=`dirname "$SCRIPT_DIR"`
 BINARY_LOCATION="$SCRIPT_DIR/`basename $SCRIPT_SOURCE`"
 
 


### PR DESCRIPTION
Trying to run IcedTea-Web in MacOSX (El Capitan) fails due to space in path.
I was trying to install it under /Library/Application Support/icedtea-web-image.
With this patch I was able to run my webstart applications.
The general class of fix is that in shell always enclose in double quotes variable expansions like a="$b".
The patch fixes PORTABLE_ITW_HOME as it should.

The patch doesn't change BINARY_LOCATION (next line) when it should.
Basically BINARY_LOCATION shouldn't work but it does and so I left it unchanged.
The following attached small test demonstrates this behavior.

and here is its output if you don't feel performing the test yourself. The test is on linux but it has the same behavior in MacOSX (El Capitan)

[test.log](https://github.com/AdoptOpenJDK/IcedTea-Web/files/3268316/test.log)
[javaws.sh.txt](https://github.com/AdoptOpenJDK/IcedTea-Web/files/3268317/javaws.sh.txt)
