### PR TITLE
Add system property from commandline test case

### DIFF
--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/testcase1/SystemPropertiesSetTest.java
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/testcase1/SystemPropertiesSetTest.java
@@ -49,11 +49,12 @@ public class SystemPropertiesSetTest implements IntegrationTest {
         tmpItwHome.createTrustSettings(jnlpUrl);
 
         // when
-        final String[] args = {"-jnlp", jnlpUrl, "-nosecurity", "-Xnofork", "-headless"};
+        final String[] args = {"-jnlp", jnlpUrl, "-nosecurity", "-Xnofork", "-headless", "-property", "key3=SystemPropertyAsCommandLineArgument"};
         Boot.main(args);
 
         // then
-        assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key1"), containsString("value1"));
-        assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key2"), containsString("value2"));
+        assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key1"), containsString("SystemPropertyViaJnlpFile1"));
+        assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key2"), containsString("System Property Via Jnlp File2"));
+        assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key3"), containsString("SystemPropertyAsCommandLineArgument"));
     }
 }

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/testcase1/jnlps/SimpleJavaApplicationWithProperties.jnlp
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/testcase1/jnlps/SimpleJavaApplicationWithProperties.jnlp
@@ -11,8 +11,8 @@
     <resources>
         <j2se version="1.8+"/>
         <jar href="resources/App-SimpleJavaApplication.jar" main="true"/>
-        <property name="key1" value="value1"/>
-        <property name="key2" value="value2"/>
+        <property name="key1" value="SystemPropertyViaJnlpFile1"/>
+        <property name="key2" value="System Property Via Jnlp File2"/>
     </resources>
 
     <application-desc main-class="${MAIN_CLASS}"/>


### PR DESCRIPTION
- Extend SystemPropertiesSetTest integration test to add system property from command line using "-property"
- Improved naming