### PR TITLE
Always add system property "deployment.javaws"="IcedTea-Web"

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/runtime/ApplicationInstance.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/ApplicationInstance.java
@@ -57,6 +57,9 @@ import java.security.ProtectionDomain;
 public class ApplicationInstance {
 
     private final static Logger LOG = LoggerFactory.getLogger(ApplicationInstance.class);
+    
+    public final static String DEPLOYMENT_SYSPROP = "deployment.javaws";
+    public final static String DEPLOYMENT_SYSPROP_VALUE = "IcedTea-Web";
 
     // todo: should attempt to unload the environment variables
     // installed by the application.
@@ -330,7 +333,11 @@ public class ApplicationInstance {
                 for (PropertyDesc propDesc : props) {
                     System.setProperty(propDesc.getKey(), propDesc.getValue());
                 }
-
+                
+                // The "deployment.javaws" flag is always set to "IcedTea-Web" to make it possible 
+                // for the started application to detect the execution context.
+                System.setProperty(DEPLOYMENT_SYSPROP, DEPLOYMENT_SYSPROP_VALUE);
+                
                 return null;
             }
         };

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/testcase1/SystemPropertiesSetTest.java
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/testcase1/SystemPropertiesSetTest.java
@@ -56,5 +56,10 @@ public class SystemPropertiesSetTest implements IntegrationTest {
         assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key1"), containsString("SystemPropertyViaJnlpFile1"));
         assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key2"), containsString("System Property Via Jnlp File2"));
         assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("key3"), containsString("SystemPropertyAsCommandLineArgument"));
+        
+        // The "deployment.javaws" flag is always set to "IcedTea-Web" to make it possible 
+        // for the started application to detect the execution context. 
+        assertThat(getCachedFileAsProperties(tmpItwHome, SYSTEM_PROPERTIES_FILE).getProperty("deployment.javaws"), containsString("IcedTea-Web"));
     }
+    
 }


### PR DESCRIPTION
This makes it possible for the started application to detect the execution context.

Based on the presence of the system property, multi-deployment applications can adapt to the WebStart running context, and test frameworks can use special optimizations for WebStart runs.