### PR TITLE
simplify fetching JNLP file location from command line argument

### DIFF
--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/commandline/CommandLineOptionsParser.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/commandline/CommandLineOptionsParser.java
@@ -100,7 +100,7 @@ public class CommandLineOptionsParser {
         if (mainArgumentList.size() > 0) {
             return mainArgumentList.get(0);
         }
-        return "";
+        return null;
     }
 
     public List<String> getMainArgs() {

--- a/common/src/test/java/net/adoptopenjdk/icedteaweb/commandline/CommandLineOptionsParserTest.java
+++ b/common/src/test/java/net/adoptopenjdk/icedteaweb/commandline/CommandLineOptionsParserTest.java
@@ -167,7 +167,7 @@ public class CommandLineOptionsParserTest {
         List<String> values = parser.getParams(CommandLineOptions.ARG);
         assertEquals(6, values.size());
         assertTrue(parser.mainArgExists());
-        assertEquals("File.jnlp",parser.getMainArg());
+        assertEquals("File.jnlp", parser.getMainArg());
         assertEquals(0, values.indexOf("blah1"));
         assertEquals(1, values.indexOf("blah2"));
         assertEquals(2, values.indexOf("blah3"));
@@ -180,7 +180,7 @@ public class CommandLineOptionsParserTest {
     public void testMultipleOptionsWithNoArgsCombinedWithMultipleOptions() {
         String[] args = {"-arg", "-update=green", "-version",
                 "-arg", "-about",
-                "-arg", "blah1", "blah2", "blah3","-about", "-arg",
+                "-arg", "blah1", "blah2", "blah3", "-about", "-arg",
                 "blah4", "blah5", "blah6", "File.jnlp", "-headless", "-noupdate"};
         CommandLineOptionsParser parser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
         assertTrue(parser.hasOption(CommandLineOptions.ABOUT));
@@ -206,7 +206,7 @@ public class CommandLineOptionsParserTest {
 
     @Test
     public void testSameTagMultipleTimesWithMainArg() {
-        String[] args = {"-headless", "-headless","File.jnlp", "-headless", "-headless", "-headless"};
+        String[] args = {"-headless", "-headless", "File.jnlp", "-headless", "-headless", "-headless"};
         CommandLineOptionsParser parser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
 
         assertTrue(parser.mainArgExists());
@@ -220,7 +220,7 @@ public class CommandLineOptionsParserTest {
         CommandLineOptionsParser parser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
 
         assertFalse(parser.mainArgExists());
-        assertEquals("",parser.getMainArg());
+        assertEquals(null, parser.getMainArg());
         assertTrue(parser.hasOption(CommandLineOptions.HEADLESS));
     }
 
@@ -277,7 +277,7 @@ public class CommandLineOptionsParserTest {
         assertTrue(CommandLineOptionsParser.stringEqualsOption("--headless", CommandLineOptions.HEADLESS));
         assertTrue(CommandLineOptionsParser.stringEqualsOption("---headless", CommandLineOptions.HEADLESS));
     }
-    
+
     @Test
     public void testOptionsSyntaxNegative() {
         assertFalse(CommandLineOptionsParser.stringEqualsOption(" -headless", CommandLineOptions.HEADLESS));

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/Boot.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/Boot.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.isNull;
 import static net.adoptopenjdk.icedteaweb.IcedTeaWebConstants.JAVAWS;
 import static net.adoptopenjdk.icedteaweb.i18n.Translator.R;
 
@@ -250,6 +251,9 @@ public final class Boot implements PrivilegedAction<Void> {
     }
 
     static String fixJnlpProtocol(String param) {
+        if (isNull(param) || param.isEmpty()) {
+            return null;
+        }
         //remove jnlp: for case like jnlp:https://some.app/file.jnlp
         if (param.matches("^jnlp[s]?:.*://.*")) {
             param = param.replaceFirst("^jnlp[s]?:", "");
@@ -291,7 +295,7 @@ public final class Boot implements PrivilegedAction<Void> {
      */
     static URL getFileLocation() {
 
-        final String location = getJnlpFileLocationFromCommandLineArguments();
+        final String location = getJnlpFileLocationFromCommandLineArguments(optionParser);
 
         if (location == null) {
             handleMessage();
@@ -326,16 +330,16 @@ public final class Boot implements PrivilegedAction<Void> {
      *
      * @return the file location or null if no file location can be found in the command line arguments.
      */
-    private static String getJnlpFileLocationFromCommandLineArguments() {
-        if (optionParser.hasOption(CommandLineOptions.JNLP)) {
-            return fixJnlpProtocol(optionParser.getParam(CommandLineOptions.JNLP));
+    static String getJnlpFileLocationFromCommandLineArguments(final CommandLineOptionsParser commandLineOptionsParser) {
+        if (commandLineOptionsParser.hasOption(CommandLineOptions.JNLP)) {
+            return fixJnlpProtocol(commandLineOptionsParser.getParam(CommandLineOptions.JNLP));
         }
-        else if (optionParser.hasOption(CommandLineOptions.HTML)) {
-            return optionParser.getParam(CommandLineOptions.HTML);
+        else if (commandLineOptionsParser.hasOption(CommandLineOptions.HTML)) {
+            return commandLineOptionsParser.getParam(CommandLineOptions.HTML);
         }
-        else if (optionParser.mainArgExists()) {
+        else if (commandLineOptionsParser.mainArgExists()) {
             // so file location must be in the list of arguments, take the first one as best effort, ignore the others
-            return fixJnlpProtocol(optionParser.getMainArg());
+            return fixJnlpProtocol(commandLineOptionsParser.getMainArg());
         }
         // no file location available as argument
         return null;

--- a/core/src/test/java/net/sourceforge/jnlp/runtime/BootTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/runtime/BootTest.java
@@ -36,9 +36,15 @@
  */
 package net.sourceforge.jnlp.runtime;
 
+import net.adoptopenjdk.icedteaweb.commandline.CommandLineOptionsDefinition;
+import net.adoptopenjdk.icedteaweb.commandline.CommandLineOptionsParser;
 import net.sourceforge.jnlp.util.logging.NoStdOutErrTest;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 public class BootTest extends NoStdOutErrTest {
 
@@ -52,4 +58,76 @@ public class BootTest extends NoStdOutErrTest {
         Assert.assertEquals("https://www.com/file.jnlp", Boot.fixJnlpProtocol("jnlps:https://www.com/file.jnlp"));
     }
 
+    @Test
+    public void fixJnlpProtocolTestWithNullArgument() {
+        assertNull(Boot.fixJnlpProtocol(null));
+    }
+
+    @Test
+    public void getValidJnlpFileLocationFromCommandLineArguments() {
+        // given
+        String[] args = {"-nosecurity", "-Xnofork", "-jnlp", "https://www.somedomain.com/some.jnlp"};
+        CommandLineOptionsParser optionsParser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
+
+        // when
+        final String jnlpFileLocation = Boot.getJnlpFileLocationFromCommandLineArguments(optionsParser);
+
+        // then
+        assertThat(jnlpFileLocation, is("https://www.somedomain.com/some.jnlp"));
+    }
+
+    @Test
+    public void getValidJnlpFileLocationFromCommandLineArgumentsWithUnknownExtraArgument() {
+        // given
+        String[] args = {"-nosecurity", "-Xnofork", "-jnlp", "https://www.somedomain.com/some.jnlp", "-unknownExtraArgument"};
+        CommandLineOptionsParser optionsParser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
+
+        // when
+        final String jnlpFileLocation = Boot.getJnlpFileLocationFromCommandLineArguments(optionsParser);
+
+        // then
+        assertThat(jnlpFileLocation, is("https://www.somedomain.com/some.jnlp"));
+    }
+
+    @Test
+    public void getValidJnlpFileLocationFromCommandLineArgumentsWithHtmlArgument() {
+        // given
+        String[] args = {"-nosecurity", "-Xnofork", "-html", "https://www.somedomain.com/some.jnlp"};
+        CommandLineOptionsParser optionsParser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
+
+        // when
+        final String jnlpFileLocation = Boot.getJnlpFileLocationFromCommandLineArguments(optionsParser);
+
+        // then
+        assertThat(jnlpFileLocation, is("https://www.somedomain.com/some.jnlp"));
+    }
+
+    @Test
+    public void getValidJnlpFileLocationFromCommandLineArgumentsWithUnknownExtraArgumentWithoutExplizitJnlpOption() {
+        // given
+        String[] args = {"-nosecurity", "-Xnofork", "https://www.somedomain.com/some.jnlp", "-unknownExtraArgument"};
+        CommandLineOptionsParser optionsParser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
+
+        // when
+        final String jnlpFileLocation = Boot.getJnlpFileLocationFromCommandLineArguments(optionsParser);
+
+        // then
+        assertThat(jnlpFileLocation, is("https://www.somedomain.com/some.jnlp"));
+    }
+
+    @Test
+    public void dontFindJnlpFileLocationInCommandLineArguments() {
+        String[] args = {"-nosecurity", "-Xnofork"};
+        CommandLineOptionsParser optionsParser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
+
+        assertNull(Boot.getJnlpFileLocationFromCommandLineArguments(optionsParser));
+    }
+
+    @Test
+    public void dontFindJnlpFileLocationInCommandLineArgumentsWithExplizitJnlpOption() {
+        String[] args = {"-nosecurity", "-Xnofork", "-jnlp"};
+        CommandLineOptionsParser optionsParser = new CommandLineOptionsParser(args, CommandLineOptionsDefinition.getJavaWsOptions());
+
+        assertNull(Boot.getJnlpFileLocationFromCommandLineArguments(optionsParser));
+    }
 }


### PR DESCRIPTION
- simplify fetching JNLP file location from command line argument
- be more tolerant for unknown extra arguments by ignoring them when fetching JNLP file location instead of throwing an InvalidArgumentException
