### PR TITLE
fix systemjar detection that fails wrongly when path case is different

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/launch/JvmLauncherHolder.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/launch/JvmLauncherHolder.java
@@ -16,6 +16,9 @@
 //
 package net.adoptopenjdk.icedteaweb.launch;
 
+import net.adoptopenjdk.icedteaweb.logging.Logger;
+import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -23,6 +26,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class JvmLauncherHolder {
 
+    private final static Logger LOG = LoggerFactory.getLogger(JvmLauncherHolder.class);
     private static JvmLauncher launcher;
 
     public static JvmLauncher getLauncher() {
@@ -39,6 +43,7 @@ public class JvmLauncherHolder {
         if (JvmLauncherHolder.launcher != null) {
             throw new IllegalStateException("JvmLauncher already set.");
         }
+        LOG.info("JvmLauncher set to {}.", launcher.getClass().getName());
         JvmLauncherHolder.launcher = launcher;
     }
 }

--- a/core/src/main/java/net/sourceforge/jnlp/ItwJvmLauncher.java
+++ b/core/src/main/java/net/sourceforge/jnlp/ItwJvmLauncher.java
@@ -18,19 +18,26 @@ package net.sourceforge.jnlp;
 
 import net.adoptopenjdk.icedteaweb.StreamUtils;
 import net.adoptopenjdk.icedteaweb.launch.JvmLauncher;
+import net.adoptopenjdk.icedteaweb.logging.Logger;
+import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static net.sourceforge.jnlp.Launcher.KEY_JAVAWS_LOCATION;
 
 /**
  * Implementation of {@link JvmLauncher} which uses the IcedTea-Web launcher to start a new JVM.
  */
 public class ItwJvmLauncher implements JvmLauncher {
+    private final static Logger LOG = LoggerFactory.getLogger(ItwJvmLauncher.class);
 
     @Override
     public void launchExternal(final JNLPFile jnlpFile, final List<String> args) throws Exception {
+        requireNonNull(jnlpFile, "JNLPFile must not be null.");
+        requireNonNull(args, "args must not be null.");
+
         launchExternal(jnlpFile.getNewVMArgs(), args);
     }
 
@@ -51,6 +58,8 @@ public class ItwJvmLauncher implements JvmLauncher {
         }
 
         commands.addAll(javawsArgs);
+
+        LOG.info("About to launch external with commands: '{}'", commands.toString());
 
         final Process p = new ProcessBuilder()
                 .command(commands)

--- a/core/src/main/java/net/sourceforge/jnlp/Launcher.java
+++ b/core/src/main/java/net/sourceforge/jnlp/Launcher.java
@@ -322,7 +322,7 @@ public class Launcher {
         try {
             getLauncher().launchExternal(file, javawsArgs);
         } catch (NullPointerException ex) {
-            throw launchError(new LaunchException(null, null, "Fatal", "External Launch Error", "Could not determine location of javaws.jar.", "An attempt was made to launch a JNLP file in another JVM, but the javaws.jar could not be located.  In order to launch in an external JVM, the runtime must be able to locate the javaws.jar file."));
+            throw launchError(new LaunchException(null, ex, "Fatal", "External Launch Error", "Could not determine location of javaws.jar.", "An attempt was made to launch a JNLP file in another JVM, but the javaws.jar could not be located.  In order to launch in an external JVM, the runtime must be able to locate the javaws.jar file."));
         } catch (Exception ex) {
             throw launchError(new LaunchException(null, ex, "Fatal", "External Launch Error", "Could not launch JNLP file.", "The application has not been initialized, for more information execute javaws/browser from the command line and send a bug report."));
         }

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPPolicy.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPPolicy.java
@@ -174,16 +174,18 @@ public class JNLPPolicy extends Policy {
      * Returns true if the CodeSource corresponds to a system jar. That is,
      * it's part of the JRE.
      */
-    private boolean isSystemJar(CodeSource source) {
+    private boolean isSystemJar(final CodeSource source) {
         if (source == null || source.getLocation() == null) {
             return false;
         }
 
         // anything in JRE/lib/ext is a system jar and has full permissions
-        String sourceProtocol = source.getLocation().getProtocol();
-        String sourcePath = source.getLocation().getPath();
+        final String sourceProtocol = source.getLocation().getProtocol();
+        final String sourcePath = source.getLocation().getPath();
+        final String jreExtDirRawPath = jreExtDir.getRawPath();
+
         if (sourceProtocol.toUpperCase().equals("FILE") &&
-                sourcePath.startsWith(jreExtDir.getRawPath())) {
+                sourcePath.toLowerCase().startsWith(jreExtDirRawPath.toLowerCase())) {
             return true;
         }
 


### PR DESCRIPTION
depending on which OS and how Boot is called system jars are not detected as such and this do not get allPermissions but end up in a checkPermission loop.

<img width="1257" alt="Screenshot 2019-07-25 at 10 35 21" src="https://user-images.githubusercontent.com/9326167/61859238-07db1000-aec8-11e9-9836-33acac979947.png">
