### PR TITLE
small fix in getNamesForCert(X509Certificate c)

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/security/HttpsCertVerifier.java
+++ b/core/src/main/java/net/sourceforge/jnlp/security/HttpsCertVerifier.java
@@ -187,10 +187,6 @@ public class HttpsCertVerifier implements CertVerifier {
                     }
                 }
             }
-
-            if (subjAltNames != null)
-                names = names.substring(2); // remove proceeding ", "
-
         } catch (CertificateParsingException cpe) {
             LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, cpe);
         } catch (IOException ioe) {


### PR DESCRIPTION
The comma only has to be removed if derValue is null. But if derValue is null we have already thrown an NPE through derValue.getAsString(). Thus, the comma never has to be removed.