### PR TITLE
Add the jar file name to exception message

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
+++ b/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
@@ -25,7 +25,6 @@
 
 package net.sourceforge.jnlp.tools;
 
-import net.adoptopenjdk.icedteaweb.IcedTeaWebConstants;
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
 import net.adoptopenjdk.icedteaweb.logging.Logger;
 import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
@@ -301,8 +300,8 @@ public class JarCertVerifier implements CertVerifier {
                     entriesVec);
 
         } catch (Exception e) {
-            LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
-            throw new RuntimeException("Error in verify jar " + jarName);
+            LOG.error("Error in verify jar " + jarName, e);
+            throw new RuntimeException("Error in verify jar " + jarName, e);
         }
     }
 

--- a/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
+++ b/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
@@ -302,7 +302,7 @@ public class JarCertVerifier implements CertVerifier {
 
         } catch (Exception e) {
             LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
-            throw e;
+            throw new RuntimeException("Error in verify jar " + jarName);
         }
     }
 


### PR DESCRIPTION
If you start an application. with several JARs and only 1 is corrupt you currently do not see any info about the file. This PR adds the name off the JAR to the error message