### PR TITLE
AppletDesc now accept also class.class suffixed  entry point in its applet-desc xml element

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/application/AppletDesc.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/application/AppletDesc.java
@@ -127,7 +127,28 @@ public class AppletDesc implements EntryPoint {
      */
     @Override
     public String getMainClass() {
-        return mainClass;
+        return cleanMainClass();
+    }
+
+    /**
+     * https://github.com/AdoptOpenJDK/IcedTea-Web/issues/361
+     * appelts can have class specified both pkg.myclass and pkg.myclass.class
+     * There are several places in ITW where this can be applied
+     * I had decided to go eith direct getter from AppletDesc for several reasons:
+     * - it is applet-desc specific, and application-desc should not be crippeld by this
+     * - in checkForMain is palce where .class is appended, that would need to be adjsuted
+     * - checkEntryPoint is comparin main class against record in manifest.
+     * -- classes in manifest are supposed to be suffix .class free. Although you can smuggle class.class into manifest, that is usually bringing you toubles.
+     * -- eg. java -jar willnot load such main-class
+     * - I can be wrong with the manifest usage
+     * @return mainclass striped of tailing .class if any
+     */
+    private String cleanMainClass() {
+        if (mainClass == null) {
+            return mainClass;
+        } else {
+            return mainClass.replaceAll("\\.class$", "");
+        }
     }
 
     /**

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/jnlp/element/application/AppletDescTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/jnlp/element/application/AppletDescTest.java
@@ -1,0 +1,47 @@
+package net.adoptopenjdk.icedteaweb.jnlp.element.application;
+
+import net.sourceforge.jnlp.util.logging.NoStdOutErrTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.HashMap;
+
+
+public class AppletDescTest extends NoStdOutErrTest {
+
+    @Test
+    public void testClassIsNotStrippedAccidentally() throws Exception {
+        Assert.assertEquals("mainClass", createAppletWithMain("mainClass").getMainClass());
+        Assert.assertEquals("main.Class", createAppletWithMain("main.Class").getMainClass());
+        Assert.assertEquals("mainclass", createAppletWithMain("mainclass").getMainClass());
+        Assert.assertEquals("mainAclass", createAppletWithMain("mainAclass").getMainClass());
+        Assert.assertEquals("mainclassa", createAppletWithMain("mainclassa").getMainClass());
+        Assert.assertEquals("main.classa", createAppletWithMain("main.classa").getMainClass());
+    }
+
+    @Test
+    public void testClassIsStrippedProperly() throws Exception {
+        Assert.assertEquals("main", createAppletWithMain("main.class").getMainClass());
+    }
+
+    private static AppletDesc createAppletWithMain(String mainClass) throws Exception {
+        return new AppletDesc("appler", mainClass, new URL("http", "localhost", "doc"), 100, 100, new HashMap<>());
+    }
+
+    private static ApplicationDesc createApplicationWithMain(String mainClass) throws Exception {
+        return new ApplicationDesc(mainClass, new String[0]);
+    }
+
+    @Test
+    public void testClassIsNotStrippedAccidentallyApplication() throws Exception {
+        Assert.assertEquals("mainClass", createApplicationWithMain("mainClass").getMainClass());
+        Assert.assertEquals("main.Class", createApplicationWithMain("main.Class").getMainClass());
+        Assert.assertEquals("mainclass", createApplicationWithMain("mainclass").getMainClass());
+        Assert.assertEquals("mainAclass", createApplicationWithMain("mainAclass").getMainClass());
+        Assert.assertEquals("mainclassa", createApplicationWithMain("mainclassa").getMainClass());
+        Assert.assertEquals("main.classa", createApplicationWithMain("main.classa").getMainClass());
+        Assert.assertEquals("main.class", createApplicationWithMain("main.class").getMainClass());
+    }
+
+}

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -164,6 +164,25 @@
                             </outputDirectory>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>appletDescMainClassWithClass</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <includes>
+                                <include>**/common/*.class</include>
+                                <include>**/reproducers/appletDescMainClassWithClass/**/*.class</include>
+                            </includes>
+                            <finalName>App</finalName>
+                            <classifier>appletDescMainClassWithClass</classifier>
+                            <outputDirectory>
+                                ${project.build.directory}/test-classes/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/resources
+                            </outputDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/AppletDescMainClassWithClassTest1.java
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/AppletDescMainClassWithClassTest1.java
@@ -1,0 +1,48 @@
+package net.adoptopenjdk.icedteaweb.integration.reproducers.appletDescMainClassWithClass;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import net.adoptopenjdk.icedteaweb.client.parts.downloadindicator.DefaultDownloadIndicator;
+import net.adoptopenjdk.icedteaweb.integration.IntegrationTest;
+import net.adoptopenjdk.icedteaweb.integration.TemporaryItwHome;
+import net.adoptopenjdk.icedteaweb.integration.reproducers.appletDescMainClassWithClass.applications.AppletDescMainClassWithClass;
+import net.adoptopenjdk.icedteaweb.integration.reproducers.progressclass.applications.ProgressClassManagedApplication;
+import net.sourceforge.jnlp.runtime.Boot;
+import net.sourceforge.jnlp.runtime.JNLPRuntime;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static net.adoptopenjdk.icedteaweb.integration.reproducers.progressclass.applications.ProgressClassManagedApplication.PROGRESS_CLASS_OUTPUT_FILE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+
+public class AppletDescMainClassWithClassTest1 implements IntegrationTest {
+    private static final String JAR_NAME = "App-appletDescMainClassWithClass.jar";
+
+    @Rule
+    public TemporaryItwHome tmpItwHome = new TemporaryItwHome();
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+
+    @Test(timeout = 100_000)
+    public void appletWithNormallMainClass() throws IOException {
+        // given
+        final String jnlpUrl = setupServer(wireMock, "AppletDescMainClassWithClass1.jnlp", AppletDescMainClassWithClass.class, JAR_NAME);
+        tmpItwHome.createTrustSettings(jnlpUrl);
+
+        // when
+        final String[] args = {"-jnlp", jnlpUrl, "-nosecurity", "-Xnofork", "-headless"};
+        Boot.main(args);
+
+        // then
+        assertThat(hasCachedFile(tmpItwHome, JAR_NAME), is(true));
+        //assertThat(getCachedFileAsString(tmpItwHome, AppletDescMainClassWithClass.ID), containsString("init AppletDescMainClassWithClass"));
+    }
+
+}

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/AppletDescMainClassWithClassTest2.java
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/AppletDescMainClassWithClassTest2.java
@@ -1,0 +1,42 @@
+package net.adoptopenjdk.icedteaweb.integration.reproducers.appletDescMainClassWithClass;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import net.adoptopenjdk.icedteaweb.integration.IntegrationTest;
+import net.adoptopenjdk.icedteaweb.integration.TemporaryItwHome;
+import net.adoptopenjdk.icedteaweb.integration.reproducers.appletDescMainClassWithClass.applications.AppletDescMainClassWithClass;
+import net.sourceforge.jnlp.runtime.Boot;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+public class AppletDescMainClassWithClassTest2 implements IntegrationTest {
+    private static final String JAR_NAME = "App-appletDescMainClassWithClass.jar";
+
+    @Rule
+    public TemporaryItwHome tmpItwHome = new TemporaryItwHome();
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+
+    @Test(timeout = 100_000)
+    public void appletWithDotClassSuffixedMainClass() throws IOException {
+        // given
+        final String jnlpUrl = setupServer(wireMock, "AppletDescMainClassWithClass2.jnlp", AppletDescMainClassWithClass.class, JAR_NAME);
+        tmpItwHome.createTrustSettings(jnlpUrl);
+
+        // when
+        final String[] args = {"-jnlp", jnlpUrl, "-nosecurity", "-Xnofork", "-headless"};
+        Boot.main(args);
+
+        // then
+        assertThat(hasCachedFile(tmpItwHome, JAR_NAME), is(true));
+        //assertThat(getCachedFileAsString(tmpItwHome, AppletDescMainClassWithClass.ID), containsString("init AppletDescMainClassWithClass"));
+    }
+
+}

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/applications/AppletDescMainClassWithClass.java
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/applications/AppletDescMainClassWithClass.java
@@ -1,0 +1,29 @@
+package net.adoptopenjdk.icedteaweb.integration.reproducers.appletDescMainClassWithClass.applications;
+
+import java.applet.Applet;
+
+import static net.adoptopenjdk.icedteaweb.integration.common.ManagedApplicationFileWriter.writeFile;
+
+public class AppletDescMainClassWithClass extends Applet {
+
+    public static String ID = "AppletDescMainClassWithClass";
+
+    public void init() {
+        System.out.println("init AppletDescMainClassWithClass");
+        try {
+           // writeFile(ID, writer -> writer.write("init AppletDescMainClassWithClass"));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void start() {
+        System.out.println("start AppletDescMainClassWithClass");
+        try {
+           // writeFile(ID , writer -> writer.write("start AppletDescMainClassWithClass"));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/jnlps/AppletDescMainClassWithClass1.jnlp
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/jnlps/AppletDescMainClassWithClass1.jnlp
@@ -1,0 +1,55 @@
+<!--
+
+This file is part of IcedTea.
+
+IcedTea is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+IcedTea is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with IcedTea; see the file COPYING.  If not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA.
+
+Linking this library statically or dynamically with other modules is
+making a combined work based on this library.  Thus, the terms and
+conditions of the GNU General Public License cover the whole
+combination.
+
+As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent
+modules, and to copy and distribute the resulting executable under
+terms of your choice, provided that you also meet, for each linked
+independent module, the terms and conditions of the license of that
+module.  An independent module is a module which is not derived from
+or based on this library.  If you modify this library, you may extend
+this exception to your version of the library, but you are not
+obligated to do so.  If you do not wish to do so, delete this
+exception statement from your version.
+
+ -->
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp spec="1.0" href="AppletDescMainClassWithClass1.jnlp" codebase="http://localhost:${PORT}">
+    <information>
+        <title>main class of applet-desc</title>
+        <vendor>IcedTea</vendor>
+        <homepage href="http://icedtea.classpath.org/wiki/IcedTea-Web#Testing_IcedTea-Web"/>
+        <description>percents in width/height</description>
+        <offline/>
+    </information>
+    <resources>
+        <j2se version="1.4+"/>
+        <jar href="resources/App-appletDescMainClassWithClass.jar"/>
+    </resources>
+    <applet-desc
+            name="normal"
+            main-class="${MAIN_CLASS}">
+    </applet-desc>
+</jnlp>

--- a/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/jnlps/AppletDescMainClassWithClass2.jnlp
+++ b/integration/src/test/java/net/adoptopenjdk/icedteaweb/integration/reproducers/appletDescMainClassWithClass/jnlps/AppletDescMainClassWithClass2.jnlp
@@ -1,0 +1,56 @@
+<!--
+
+This file is part of IcedTea.
+
+IcedTea is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+IcedTea is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with IcedTea; see the file COPYING.  If not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA.
+
+Linking this library statically or dynamically with other modules is
+making a combined work based on this library.  Thus, the terms and
+conditions of the GNU General Public License cover the whole
+combination.
+
+As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent
+modules, and to copy and distribute the resulting executable under
+terms of your choice, provided that you also meet, for each linked
+independent module, the terms and conditions of the license of that
+module.  An independent module is a module which is not derived from
+or based on this library.  If you modify this library, you may extend
+this exception to your version of the library, but you are not
+obligated to do so.  If you do not wish to do so, delete this
+exception statement from your version.
+
+ -->
+
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp spec="1.0" href="AppletDescMainClassWithClass2.jnlp" codebase="http://localhost:${PORT}">
+    <information>
+        <title>main class of applet-desc</title>
+        <vendor>IcedTea</vendor>
+        <homepage href="http://icedtea.classpath.org/wiki/IcedTea-Web#Testing_IcedTea-Web"/>
+        <description>percents in width/height</description>
+        <offline/>
+    </information>
+    <resources>
+        <j2se version="1.4+"/>
+        <jar href="resources/App-appletDescMainClassWithClass.jar"/>
+    </resources>
+    <applet-desc
+            name="notnormal"
+            main-class="${MAIN_CLASS}.class">
+    </applet-desc>
+</jnlp>


### PR DESCRIPTION
https://github.com/AdoptOpenJDK/IcedTea-Web/issues/361

      appelts can have class specified both pkg.myclass and pkg.myclass.class
      There are several places in ITW where this can be applied
      I had decided to go eith direct getter from AppletDesc for several reasons:
      - it is applet-desc specific, and application-desc should not be crippeld by this
      - in checkForMain is palce where .class is appended, that would need to be adjsuted
      - checkEntryPoint is comparin main class against record in manifest.
      -- classes in manifest are supposed to be suffix .class free. Although you can smuggle class.class into manifest, that is usually bringing you toubles.
      -- eg. java -jar willnot load such main-class
      - I can be wrong with the manifest usage