### PR TITLE
Fix for the following failed test on Windows

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
+++ b/core/src/main/java/net/sourceforge/jnlp/JNLPFile.java
@@ -282,9 +282,10 @@ public class JNLPFile {
      * @throws ParseException if the JNLP file was invalid
      */
     protected JNLPFile(final URL location, final VersionString version, final ParserSettings settings, final UpdatePolicy policy, final URL forceCodebase) throws IOException, ParseException {
-        InputStream input = openURL(location, version, policy);
         this.parserSettings = settings;
-        parse(input, location, forceCodebase);
+        try (InputStream input = openURL(location, version, policy)) {
+            parse(input, location, forceCodebase);
+        }
 
         //Downloads the original jnlp file into the cache if possible
         //(i.e. If the jnlp file being launched exist locally, but it

--- a/core/src/main/java/net/sourceforge/jnlp/cache/CacheUtil.java
+++ b/core/src/main/java/net/sourceforge/jnlp/cache/CacheUtil.java
@@ -703,7 +703,7 @@ public class CacheUtil {
             path.append(location.getPort());
             path.append(File.separatorChar);
         }
-        String locationPath = location.getPath().replace('/', File.separatorChar);
+        String locationPath = location.getPath();
         String query = "";
         if (location.getQuery() != null) {
             query = location.getQuery();
@@ -723,7 +723,7 @@ public class CacheUtil {
                 throw new RuntimeException(ex);
             }
         } else {
-            path.append(locationPath);
+            path.append(locationPath.replace('/', File.separatorChar));
             if (location.getQuery() != null && !location.getQuery().trim().isEmpty()) {
                 path.append(".").append(location.getQuery());
             }

--- a/core/src/test/java/net/sourceforge/jnlp/cache/CacheUtilTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/cache/CacheUtilTest.java
@@ -90,7 +90,7 @@ public class CacheUtilTest {
     }
 
     @Test
-    public void tesPathUpNoGoBasic() throws Exception {
+    public void testPathUpNoGoBasic() throws Exception {
         final URL u = new URL("https://example.com/applet/../my.jar");
         final File expected = new File("/tmp/https/example.com/abca4723622ed60db3dea12cbe2402622a74f7a49b73e23b55988e4eee5ded.jar");
         File r = CacheUtil.urlToPath(u, "/tmp/");
@@ -98,7 +98,7 @@ public class CacheUtilTest {
     }
 
     @Test
-    public void tesPathUpNoGoBasicLong() throws Exception {
+    public void testPathUpNoGoBasicLong() throws Exception {
         final URL u = new URL("https://example.com/applet/../my.jar.q_SlNFU1NJT05JRD02OUY1ODVCNkJBOTM1NThCQjdBMTA5RkQyNDZEQjEwRi5wcm9kX3RwdG9tY2F0MjE1X2p2bTsgRW50cnVzdFRydWVQYXNzUmVkaXJlY3RVcmw9Imh0dHBzOi8vZWZzLnVzcHRvLmdvdi9FRlNXZWJVSVJlZ2lzdGVyZWQvRUZTV2ViUmVnaXN0ZXJlZCI7IFRDUFJPRFBQQUlSc2Vzc2lvbj02MjIxMjk0MTguMjA0ODAuMDAwMA\"");
         final File expected = new File("/tmp/https/example.com/ec97413e3f6eee8215ecc8375478cc1ae5f44f18241b9375361d5dfcd7b0ec");
         File r = CacheUtil.urlToPath(u, "/tmp/");
@@ -106,7 +106,7 @@ public class CacheUtilTest {
     }
 
     @Test
-    public void tesPathUpNoGoBasic2() throws Exception {
+    public void testPathUpNoGoBasic2() throws Exception {
         final URL u = new URL("https://example.com/../my.jar");
         final File expected = new File("/tmp/https/example.com/eb1a56bed34523dbe7ad84d893ebc31a8bbbba9ce3f370e42741b6a5f067c140.jar");
         File r = CacheUtil.urlToPath(u, "/tmp/");
@@ -114,7 +114,7 @@ public class CacheUtilTest {
     }
 
     @Test
-    public void tesPathUpNoGoBasicEvil() throws Exception {
+    public void testPathUpNoGoBasicEvil() throws Exception {
         final URL u = new URL("https://example.com/../../my.jar");
         final File expected = new File("/tmp/https/example.com/db464f11d68af73e37eefaef674517b6be23f0e4a5738aaee774ecf5b58f1bfc.jar");
         File r = CacheUtil.urlToPath(u, "/tmp/");
@@ -122,14 +122,14 @@ public class CacheUtilTest {
     }
 
     @Test
-    public void tesPathUpNoGoBasicEvil2() throws Exception {
+    public void testPathUpNoGoBasicEvil2() throws Exception {
         final URL u = new URL("https://example.com:99/../../../my.jar");
         final File expected = new File("/tmp/https/example.com/99/95401524c345e0d554d4d77330e86c98a77b9bb58a0f93094204df446b356.jar");
         File r = CacheUtil.urlToPath(u, "/tmp/");
         Assert.assertEquals(expected, r);
     }
     @Test
-    public void tesPathUpNoGoBasicEvilest() throws Exception {
+    public void testPathUpNoGoBasicEvilest() throws Exception {
         final URL u = new URL("https://example2.com/something/../../../../../../../../../../../my.jar");
         final File expected = new File("/tmp/https/example2.com/a8df64388f5b84d5f635e4d6dea5f4d2f692ae5381f8ec6736825ff8d6ff2c0.jar");
         File r = CacheUtil.urlToPath(u, "/tmp/");


### PR DESCRIPTION
AssertionError in CacheUtilTest:
tesPathUpNoGoBasic
tesPathUpNoGoBasic2
tesPathUpNoGoBasicEvil
tesPathUpNoGoBasicEvil2
tesPathUpNoGoBasicEvilest
tesPathUpNoGoBasicLong
testNameGotHashedToo
testQueryGotHAshedToo

IOException in JNLPClassLoaderTest:
testRelativePathInNestedJars
testRelativePathInUrl