### PR TITLE
read from stdout/stderr in separate thread to prevent hanging of process

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/JVMPanel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/JVMPanel.java
@@ -64,6 +64,7 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+import java.util.concurrent.Future;
 
 @SuppressWarnings("serial")
 public class JVMPanel extends NamedBorderPanel {
@@ -257,9 +258,11 @@ public class JVMPanel extends NamedBorderPanel {
         Integer r = null;
         try {
             p = sb.start();
+            final Future<String> stdOut = ProcessUtils.readStdOutAsUtf8(p);
+            final Future<String> stdErr = ProcessUtils.readStdErrAsUtf8(p);
             ProcessUtils.waitForSafely(p);
-            processErrorStream = StreamUtils.readStreamAsString(p.getErrorStream());
-            processStdOutStream = StreamUtils.readStreamAsString(p.getInputStream());
+            processErrorStream = stdErr.get();
+            processStdOutStream = stdOut.get();
             r = p.exitValue();
             LOG.debug(processErrorStream);
             LOG.info(processStdOutStream);

--- a/core/src/main/java/net/sourceforge/jnlp/services/XBasicService.java
+++ b/core/src/main/java/net/sourceforge/jnlp/services/XBasicService.java
@@ -249,6 +249,7 @@ class XBasicService implements BasicService {
             final ProcessBuilder pb = new ProcessBuilder(cmdarray);
             pb.inheritIO();
             final Process p = pb.start();
+            ProcessUtils.ignoreStdOutAndStdErr(p);
             ProcessUtils.waitForSafely(p);
             return (p.exitValue() == 0);
         } catch (Exception e) {

--- a/integration/src/main/java/net/adoptopenjdk/icedteaweb/integration/ItwLauncher.java
+++ b/integration/src/main/java/net/adoptopenjdk/icedteaweb/integration/ItwLauncher.java
@@ -72,6 +72,7 @@ public class ItwLauncher {
         final Process p = builder
                 .start();
 
+        ProcessUtils.ignoreStdOutAndStdErr(p);
         ProcessUtils.waitForSafely(p);
 
         return p.exitValue();

--- a/test-extensions/src/main/java/net/adoptopenjdk/icedteaweb/testing/ThreadedProcess.java
+++ b/test-extensions/src/main/java/net/adoptopenjdk/icedteaweb/testing/ThreadedProcess.java
@@ -165,6 +165,7 @@ public class ThreadedProcess extends Thread {
                     });
                     t.start();
                 }
+                ProcessUtils.ignoreStdOutAndStdErr(p);
                 ProcessUtils.waitForSafely(p);
                 exitCode = p.exitValue();
                 Thread.sleep(500); //this is giving to fast done processes's e/o readers time to read all. I would like to know better solution :-/


### PR DESCRIPTION
On windows a process will hang if either stdout or stderr buffer is full.
The process will wait indefinitely until some other process will read from the buffer to make space for more content

This PR adds code which will actively read stdout and stderr from processes