### PR TITLE
title property added to control panels

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/ControlPanel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/ControlPanel.java
@@ -189,7 +189,7 @@ public class ControlPanel extends JFrame {
         final Map<String, JComponent> panels = providers.values().stream()
                 .sorted(Comparator.comparingInt(ControlPanelProvider::getOrder))
                 .collect(Collectors.toMap(ControlPanelProvider::getTitle, p -> p.createPanel(config), (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw new IllegalStateException(String.format("Duplicate title %s", u));
                 }, LinkedHashMap::new));
 
         final CardLayout cardLayout = new CardLayout();
@@ -198,10 +198,10 @@ public class ControlPanel extends JFrame {
                 .map(JComponent::getMinimumSize)
                 .reduce((a, b) -> new Dimension(Math.max(a.width, b.width), Math.max(a.height, b.height)))
                 .orElse(new Dimension());
-        panels.forEach((name, component) -> {
+        panels.forEach((title, component) -> {
             component.setPreferredSize(minDimension);
-            settingsPanel.add(component, name);
-            cardLayout.addLayoutComponent(component, name);
+            settingsPanel.add(component, title);
+            cardLayout.addLayoutComponent(component, title);
         });
         final JPanel settingsDetailPanel = new JPanel();
         settingsDetailPanel.setLayout(new BorderLayout());

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/ControlPanel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/ControlPanel.java
@@ -188,7 +188,7 @@ public class ControlPanel extends JFrame {
 
         final Map<String, JComponent> panels = providers.values().stream()
                 .sorted(Comparator.comparingInt(ControlPanelProvider::getOrder))
-                .collect(Collectors.toMap(ControlPanelProvider::getName, p -> p.createPanel(config), (u, v) -> {
+                .collect(Collectors.toMap(ControlPanelProvider::getTitle, p -> p.createPanel(config), (u, v) -> {
                     throw new IllegalStateException(String.format("Duplicate key %s", u));
                 }, LinkedHashMap::new));
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/AboutPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/AboutPanelProvider.java
@@ -7,8 +7,15 @@ import javax.swing.JComponent;
 
 public class AboutPanelProvider implements ControlPanelProvider {
 
+    public static final String NAME = "AboutPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return "About Panel";
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/AboutPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/AboutPanelProvider.java
@@ -1,13 +1,14 @@
 package net.adoptopenjdk.icedteaweb.client.controlpanel.panels.provider;
 
 import net.adoptopenjdk.icedteaweb.client.controlpanel.panels.AboutPanel;
+import net.adoptopenjdk.icedteaweb.i18n.Translator;
 import net.sourceforge.jnlp.config.DeploymentConfiguration;
 
 import javax.swing.JComponent;
 
 public class AboutPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "AboutPanel";
+    private static final String NAME = "AboutPanel";
 
     @Override
     public String getName() {
@@ -16,7 +17,7 @@ public class AboutPanelProvider implements ControlPanelProvider {
 
     @Override
     public String getTitle() {
-        return "About Panel";
+        return Translator.R("CPTabAbout");
     }
 
     @Override

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CacheSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CacheSettingsPanelProvider.java
@@ -8,8 +8,16 @@ import javax.swing.JComponent;
 
 public class CacheSettingsPanelProvider implements ControlPanelProvider {
 
+    public static final String NAME = "TemporaryInternetFilesPanel";
+
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabCache");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CacheSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CacheSettingsPanelProvider.java
@@ -8,8 +8,7 @@ import javax.swing.JComponent;
 
 public class CacheSettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "TemporaryInternetFilesPanel";
-
+    private static final String NAME = "TemporaryInternetFilesPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CertificatesSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CertificatesSettingsPanelProvider.java
@@ -11,8 +11,15 @@ import java.awt.BorderLayout;
 
 public class CertificatesSettingsPanelProvider implements ControlPanelProvider {
 
+    public static final String NAME = "CertificatePane";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPHeadCertificates");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CertificatesSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/CertificatesSettingsPanelProvider.java
@@ -11,7 +11,7 @@ import java.awt.BorderLayout;
 
 public class CertificatesSettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "CertificatePane";
+    private static final String NAME = "CertificatePane";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/ControlPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/ControlPanelProvider.java
@@ -6,6 +6,8 @@ import javax.swing.JComponent;
 
 public interface ControlPanelProvider {
 
+    String getTitle();
+
     String getName();
 
     int getOrder();

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DebugSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DebugSettingsPanelProvider.java
@@ -8,8 +8,15 @@ import javax.swing.JComponent;
 
 public class DebugSettingsPanelProvider implements ControlPanelProvider {
 
+    public static final String NAME = "DebuggingPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabDebugging");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DebugSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DebugSettingsPanelProvider.java
@@ -8,7 +8,7 @@ import javax.swing.JComponent;
 
 public class DebugSettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "DebuggingPanel";
+    private static final String NAME = "DebuggingPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DesktopSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DesktopSettingsPanelProvider.java
@@ -8,7 +8,7 @@ import javax.swing.JComponent;
 
 public class DesktopSettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "DesktopShortcutPanel";
+    private static final String NAME = "DesktopShortcutPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DesktopSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/DesktopSettingsPanelProvider.java
@@ -7,8 +7,16 @@ import net.sourceforge.jnlp.config.DeploymentConfiguration;
 import javax.swing.JComponent;
 
 public class DesktopSettingsPanelProvider implements ControlPanelProvider {
+
+    public static final String NAME = "DesktopShortcutPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabDesktopIntegration");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/JvmSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/JvmSettingsPanelProvider.java
@@ -8,7 +8,7 @@ import javax.swing.JComponent;
 
 public class JvmSettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "JVMPanel";
+    private static final String NAME = "JVMPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/JvmSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/JvmSettingsPanelProvider.java
@@ -7,8 +7,16 @@ import net.sourceforge.jnlp.config.DeploymentConfiguration;
 import javax.swing.JComponent;
 
 public class JvmSettingsPanelProvider implements ControlPanelProvider {
+
+    public static final String NAME = "JVMPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabJVMSettings");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/NetworkSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/NetworkSettingsPanelProvider.java
@@ -7,8 +7,17 @@ import net.sourceforge.jnlp.config.DeploymentConfiguration;
 import javax.swing.JComponent;
 
 public class NetworkSettingsPanelProvider implements ControlPanelProvider {
+
+    public static final String NAME = "NetworkSettingsPanel";
+
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabNetwork");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/NetworkSettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/NetworkSettingsPanelProvider.java
@@ -8,8 +8,7 @@ import javax.swing.JComponent;
 
 public class NetworkSettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "NetworkSettingsPanel";
-
+    private static final String NAME = "NetworkSettingsPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/PolicySettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/PolicySettingsPanelProvider.java
@@ -8,7 +8,7 @@ import javax.swing.JComponent;
 
 public class PolicySettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "PolicyPanel";
+    private static final String NAME = "PolicyPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/PolicySettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/PolicySettingsPanelProvider.java
@@ -8,8 +8,15 @@ import javax.swing.JComponent;
 
 public class PolicySettingsPanelProvider implements ControlPanelProvider {
 
+    public static final String NAME = "PolicyPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabPolicy");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/SecuritySettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/SecuritySettingsPanelProvider.java
@@ -8,7 +8,7 @@ import javax.swing.JComponent;
 
 public class SecuritySettingsPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "SecuritySettingsPanel";
+    private static final String NAME = "SecuritySettingsPanel";
 
     @Override
     public String getName() {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/SecuritySettingsPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/SecuritySettingsPanelProvider.java
@@ -8,8 +8,15 @@ import javax.swing.JComponent;
 
 public class SecuritySettingsPanelProvider implements ControlPanelProvider {
 
+    public static final String NAME = "SecuritySettingsPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("CPTabSecurity");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/UnsignedAppletsTrustingListPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/UnsignedAppletsTrustingListPanelProvider.java
@@ -8,8 +8,16 @@ import net.sourceforge.jnlp.config.PathsAndFiles;
 import javax.swing.JComponent;
 
 public class UnsignedAppletsTrustingListPanelProvider implements ControlPanelProvider {
+
+    public static final String NAME = "UnsignedAppletsTrustingListPanel";
+
     @Override
     public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
         return Translator.R("APPEXTSECControlPanelExtendedAppletSecurityTitle");
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/UnsignedAppletsTrustingListPanelProvider.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/panels/provider/UnsignedAppletsTrustingListPanelProvider.java
@@ -9,7 +9,7 @@ import javax.swing.JComponent;
 
 public class UnsignedAppletsTrustingListPanelProvider implements ControlPanelProvider {
 
-    public static final String NAME = "UnsignedAppletsTrustingListPanel";
+    private static final String NAME = "UnsignedAppletsTrustingListPanel";
 
     @Override
     public String getName() {


### PR DESCRIPTION
Based on this we can remove unused panels (like the JVM Panel) in OWS. The current implementation used the name that depends on the translation