### PR TITLE
Stuck downloadingresources

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/cache/CachedDaemonThreadPoolProvider.java
+++ b/core/src/main/java/net/sourceforge/jnlp/cache/CachedDaemonThreadPoolProvider.java
@@ -81,6 +81,6 @@ class CachedDaemonThreadPoolProvider {
         }
     }
 
-    public static final ExecutorService DAEMON_THREAD_POOL = Executors.newCachedThreadPool(new DaemonThreadFactory());
+    public static final ExecutorService DAEMON_THREAD_POOL = Executors.newFixedThreadPool(3, new DaemonThreadFactory());
 
 }


### PR DESCRIPTION
We've had some problems with downloads getting stuck when starting an application. Problem seemed to be that IcedTea-Web started too many connections in a short amount of time, up to 100 in our case. This seemed to cause the network or firewall to freak out a bit.

Limiting the amount of parallel downloads solved the problem for us. Three is an arbitrary number we just made up, but it seemed to solve the problem without increasing the total load time. We had to split initializing and running the download to fix the progress indicator from going crazy.