### PR TITLE
#313 - Fix Windows launchers build

### DIFF
--- a/launchers/configure.sh
+++ b/launchers/configure.sh
@@ -75,7 +75,7 @@ if [ "x$ITW_LIBS" == "xDISTRIBUTION" ] ; then
   readonly JAVAWS_SRC=`ls $PROJECT_TOP/artifact-no-dependencies/target/icedtea-web-no-dependencies-*.jar | grep -v sources | grep -v javadoc`
   readonly JAVAWS_SRC_SRC=`ls $PROJECT_TOP/artifact-no-dependencies/target/icedtea-web-no-dependencies-*.jar | grep sources`
 else
-  readonly JAVAWS_SRC=`ls $PROJECT_TOP/artifact-all-dependencies/target/icedtea-web-all-dependencies-*.jar | grep -v sources | grep -v javadoc`
+  readonly JAVAWS_SRC=`ls $PROJECT_TOP/artifact-all-dependencies/target/icedtea-web-all-dependencies-*.jar | grep -v sources | grep -v javadoc | grep -v shaded`
   readonly JAVAWS_SRC_SRC=`ls $PROJECT_TOP/artifact-all-dependencies/target/icedtea-web-all-dependencies-*.jar | grep sources`
 fi
 


### PR DESCRIPTION
The current command in configure.sh selects two jar files (the normal one and the shaded one) and provokes a strange error when trying to build launchers on Windows.

I assume we want the shaded jar and not the normal one.