### PR TITLE
Support unsigned jars (only by specific config)

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPClassLoader.java
@@ -354,8 +354,7 @@ public class JNLPClassLoader extends URLClassLoader {
     }
 
     private static boolean isCertUnderestimated() {
-        return Boolean.parseBoolean(JNLPRuntime.getConfiguration().getProperty(ConfigurationConstants.KEY_SECURITY_ITW_IGNORECERTISSUES))
-                && !JNLPRuntime.isSecurityEnabled();
+        return Boolean.parseBoolean(JNLPRuntime.getConfiguration().getProperty(ConfigurationConstants.KEY_SECURITY_ITW_IGNORECERTISSUES));
     }
 
     private static void consultCertificateSecurityException(LaunchException ex) throws LaunchException {


### PR DESCRIPTION
ITW already provide the support for unsigned jars if a specific config property is defined and if the security is deactivated. Since the property is only used at 1 place (for this check) it would make sense to depend only on this property to support unsigned jars.

@judovana do you think this is ok or do you see any security issues here?