### PR TITLE
Fix cache folder with space use case

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/runtime/CachedJarFileCallback.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/CachedJarFileCallback.java
@@ -106,7 +106,7 @@ final class CachedJarFileCallback implements URLJarFileCallBack {
 
         if (UrlUtils.isLocalFile(localUrl)) {
             // if it is known to us, just return the cached file
-            JarFile returnFile = new JarFile(localUrl.getPath());
+            JarFile returnFile = new JarFile(UrlUtils.decodeUrlQuietly(localUrl).getPath());
             
             try {
                 

--- a/core/src/test/resources/net/sourceforge/jnlp/runtime/test.jnlp
+++ b/core/src/test/resources/net/sourceforge/jnlp/runtime/test.jnlp
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<jnlp spec="6.0+" codebase=".">
+    <information>
+        <title>Test</title>
+        <vendor>IcedTea-Web</vendor>
+    </information>
+    <resources>
+        <j2se href="http://java.sun.com/products/autodl/j2se" version="1.8+" />
+        <jar href="http://localhost:8080/j1.jar"/>
+    </resources>
+    <application-desc main-class="Hello1" />
+</jnlp>


### PR DESCRIPTION
The problem is reproducible with cache folders that contain spaces. After starting an application, the resources are downloaded to cache folder but attempt to load main class fails with java.lang.ClassNotFoundException.

The problem seems to be caused by inconsistent escaping/unescaping of values of the map - net.sourceforge.jnlp.runtime.CachedJarFileCallback.mapping (associates remote URL with local URL).  Adding values to this map occurs in CachedJarFileCallback.addMapping(remoteURL, localURL) that is called from JNLPClassLoader.activateJars() which performs escaping (localFile->URI->URL) replacing spaces with %20. The getter is in CachedJarFileCallback.retrieve(URL) - for local files, it creates JarFile using escaped value and fails with FileNotFoundException (and swallows it later).The proposed fix is to unescape values for local files.