### PR TITLE
fix to finally delete old versions of resources and jnlp files from t…

### DIFF
--- a/netx/net/sourceforge/jnlp/cache/CacheUtil.java
+++ b/netx/net/sourceforge/jnlp/cache/CacheUtil.java
@@ -877,7 +877,7 @@ public class CacheUtil {
                     rStr = lruHandler.getCacheDir().getFullPath()+ rStr.substring(0, rStr.indexOf(File.separatorChar, 1));
                     long len = file.length();
 
-                    if (keep.contains(file.getPath().substring(rStr.length()))) {
+                    if (keep.contains(path)) {
                         lruHandler.removeEntry(key);
                         continue;
                     }
@@ -897,7 +897,7 @@ public class CacheUtil {
                     }
 
                     curSize += len;
-                    keep.add(file.getPath().substring(rStr.length()));
+                    keep.add(path);
 
                     for (File f : file.getParentFile().listFiles()) {
                         if (!(f.equals(file) || f.equals(pf.getStoreFile()))) {


### PR DESCRIPTION
…he cache

When a webapp receives updates, the old jnlp file and the old resource files are marked for deletion in the [resource] .info file and later deleted from the recently_used file, but not in the file system itself. Later, these files will not be deleted when you click on the "Clean by app" button because they are no longer contained in the recently_used file. This commit fixes this problem.