### PR TITLE
change file store impl to make json more compact

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/userdecision/FileStoreEntries.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/userdecision/FileStoreEntries.java
@@ -1,16 +1,45 @@
 package net.adoptopenjdk.icedteaweb.userdecision;
 
-import java.util.Collections;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
-public class FileStoreEntries {
+class FileStoreEntries {
+
+    @SuppressWarnings("unused") // this is used for identifying the serialization version in the JSON file.
+    private final String version = "1";
     private final List<FileStoreEntry> userDecisions;
 
-    public FileStoreEntries(final List<FileStoreEntry> userDecisions) {
-        this.userDecisions = Collections.unmodifiableList(userDecisions);
+    FileStoreEntries() {
+        this.userDecisions = new ArrayList<>();
     }
 
-    public List<FileStoreEntry> getUserDecisions() {
-        return userDecisions;
+    <T extends Enum<T>> Optional<T> getDecision(final URL domain, final Set<String> jarNames, final UserDecision.Key key, final Class<T> resultType) {
+        final T[] enumConstants = resultType.getEnumConstants();
+        return userDecisions.stream()
+                .filter(entry -> entry.getDomain().equals(domain))
+                .filter(entry -> entry.getJarNames().isEmpty() || entry.getJarNames().equals(jarNames))
+                .max(Comparator.comparingInt(entry -> entry.getJarNames().size()))
+                .flatMap(entry -> entry.getUserDecisionValue(key))
+                .filter(value -> Arrays.stream(enumConstants).anyMatch((t) -> t.name().equals(value)))
+                .map(value -> Enum.valueOf(resultType, value));
+    }
+
+    <T extends Enum<T>> void addDecision(final URL domain, final Set<String> jarNames, final UserDecision<T> userDecision) {
+        final FileStoreEntry foundEntry = userDecisions.stream()
+                .filter(entry -> entry.getDomain().equals(domain))
+                .filter(entry -> entry.getJarNames().equals(jarNames))
+                .findFirst()
+                .orElseGet(() -> {
+                    final FileStoreEntry newEntry = new FileStoreEntry(domain, jarNames);
+                    userDecisions.add(newEntry);
+                    return newEntry;
+                });
+
+        foundEntry.setUserDecision(userDecision);
     }
 }

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/userdecision/FileStoreEntry.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/userdecision/FileStoreEntry.java
@@ -1,54 +1,34 @@
 package net.adoptopenjdk.icedteaweb.userdecision;
 
-import net.adoptopenjdk.icedteaweb.Assert;
-
 import java.net.URL;
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
-public class FileStoreEntry {
-    private UserDecision.Key userDecisionKey;
-    private String userDecisionValue;
+class FileStoreEntry {
+    private final URL domain;
+    private final Set<String> jarNames;
+    private final Map<UserDecision.Key, String> decisions = new HashMap<>();
 
-    private URL domain;
-    private Set<String> jarNames;
-
-    public <T extends Enum<T>> FileStoreEntry(UserDecision.Key userDecisionKey, String userDecisionValue, final URL domain, final Set<String> jarNames) {
-        this.userDecisionKey = Assert.requireNonNull(userDecisionKey, "userDecisionKey");
-        this.userDecisionValue = Assert.requireNonNull(userDecisionValue, "userDecisionValue");
-        this.domain = Assert.requireNonNull(domain, "domain");
-        this.jarNames = Assert.requireNonNull(jarNames, "jarNames");
+    FileStoreEntry(final URL domain, final Set<String> jarNames) {
+        this.domain = domain;
+        this.jarNames = jarNames;
     }
 
-    public UserDecision.Key getUserDecisionKey() {
-        return userDecisionKey;
+    Optional<String> getUserDecisionValue(UserDecision.Key key) {
+        return Optional.ofNullable(decisions.get(key));
     }
 
-    public String getUserDecisionValue() {
-        return userDecisionValue;
+    <T extends Enum<T>> void setUserDecision(UserDecision<T> userDecision) {
+        decisions.put(userDecision.getKey(), userDecision.getValue().name());
     }
 
-    public URL getDomain() {
+    URL getDomain() {
         return domain;
     }
 
-    public Set<String> getJarNames() {
+    Set<String> getJarNames() {
         return jarNames;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof FileStoreEntry)) return false;
-        final FileStoreEntry that = (FileStoreEntry) o;
-        return userDecisionKey.equals(that.userDecisionKey) &&
-                userDecisionValue.equals(that.userDecisionValue) &&
-                domain.equals(that.domain) &&
-                jarNames.equals(that.jarNames);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(userDecisionKey, userDecisionValue, domain, jarNames);
     }
 }

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/userdecision/UserDecision.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/userdecision/UserDecision.java
@@ -23,8 +23,8 @@ import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 public class UserDecision<T extends Enum<T>> {
-    private Key key;
-    private T value;
+    private final Key key;
+    private final T value;
 
     public enum Key {
         CREATE_DESKTOP_SHORTCUT,

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/userdecision/UserDecisionsFileStoreTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/userdecision/UserDecisionsFileStoreTest.java
@@ -1,6 +1,7 @@
 package net.adoptopenjdk.icedteaweb.userdecision;
 
 import net.adoptopenjdk.icedteaweb.security.dialog.result.AllowDeny;
+import net.adoptopenjdk.icedteaweb.userdecision.UserDecision.Key;
 import net.adoptopenjdk.icedteaweb.xmlparser.ParseException;
 import net.sourceforge.jnlp.JNLPFile;
 import net.sourceforge.jnlp.JNLPFileFactory;
@@ -15,7 +16,7 @@ import java.util.Optional;
 
 import static net.adoptopenjdk.icedteaweb.security.dialog.result.AllowDeny.ALLOW;
 import static net.adoptopenjdk.icedteaweb.security.dialog.result.AllowDeny.DENY;
-import static net.adoptopenjdk.icedteaweb.userdecision.UserDecision.Key.RUN_UNSIGNED_APPLICATION;
+import static net.adoptopenjdk.icedteaweb.security.dialog.result.AllowDenySandbox.SANDBOX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
@@ -24,6 +25,11 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link UserDecisionsFileStore}.
  */
 public class UserDecisionsFileStoreTest {
+
+    private static final Key decisionKey = Key.RUN_UNSIGNED_APPLICATION;
+    private static final Key otherKey1 = Key.RUN_PARTIALLY_APPLICATION;
+    private static final Key otherKey2 = Key.RUN_MISSING_ALAC_APPLICATION;
+    private static final Key otherKey3 = Key.RUN_MISSING_PERMISSIONS_APPLICATION;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -43,20 +49,20 @@ public class UserDecisionsFileStoreTest {
         final JNLPFile file = loadJnlpFile("/net/sourceforge/jnlp/basic.jnlp");
 
         // when
-        final Optional<AllowDeny> result = userDecisions.getUserDecisions(RUN_UNSIGNED_APPLICATION, file, AllowDeny.class);
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
 
         // then
         assertThat(result, is(Optional.empty()));
     }
 
     @Test
-    public void shouldSaveDecisionInForApplication() throws Exception {
+    public void shouldSaveDecisionForApplication() throws Exception {
         // given
         final JNLPFile file = loadJnlpFile("/net/sourceforge/jnlp/basic.jnlp");
 
         // when
-        userDecisions.saveForApplication(file, UserDecision.of(RUN_UNSIGNED_APPLICATION, DENY));
-        final Optional<AllowDeny> result = userDecisions.getUserDecisions(RUN_UNSIGNED_APPLICATION, file, AllowDeny.class);
+        userDecisions.saveForApplication(file, UserDecision.of(decisionKey, DENY));
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
 
         // then
         assertThat(result, is(Optional.of(DENY)));
@@ -68,8 +74,8 @@ public class UserDecisionsFileStoreTest {
         final JNLPFile file = loadJnlpFile("/net/sourceforge/jnlp/basic.jnlp");
 
         // when
-        userDecisions.saveForDomain(file, UserDecision.of(RUN_UNSIGNED_APPLICATION, DENY));
-        final Optional<AllowDeny> result = userDecisions.getUserDecisions(RUN_UNSIGNED_APPLICATION, file, AllowDeny.class);
+        userDecisions.saveForDomain(file, UserDecision.of(decisionKey, DENY));
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
 
         // then
         assertThat(result, is(Optional.of(DENY)));
@@ -82,8 +88,8 @@ public class UserDecisionsFileStoreTest {
         assertTrue(store.delete());
 
         // when
-        userDecisions.saveForApplication(file, UserDecision.of(RUN_UNSIGNED_APPLICATION, DENY));
-        final Optional<AllowDeny> result = userDecisions.getUserDecisions(RUN_UNSIGNED_APPLICATION, file, AllowDeny.class);
+        userDecisions.saveForApplication(file, UserDecision.of(decisionKey, DENY));
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
 
         // then
         assertThat(result, is(Optional.of(DENY)));
@@ -93,17 +99,31 @@ public class UserDecisionsFileStoreTest {
     public void applicationShouldTakePrecedenceOverDomain() throws Exception {
         // given
         final JNLPFile file = loadJnlpFile("/net/sourceforge/jnlp/basic.jnlp");
-        assertTrue(store.delete());
 
         // when
         // save domain twice to ensure order does not matter
-        userDecisions.saveForDomain(file, UserDecision.of(RUN_UNSIGNED_APPLICATION, ALLOW));
-        userDecisions.saveForApplication(file, UserDecision.of(RUN_UNSIGNED_APPLICATION, DENY));
-        userDecisions.saveForDomain(file, UserDecision.of(RUN_UNSIGNED_APPLICATION, ALLOW));
-        final Optional<AllowDeny> result = userDecisions.getUserDecisions(RUN_UNSIGNED_APPLICATION, file, AllowDeny.class);
+        userDecisions.saveForDomain(file, UserDecision.of(decisionKey, ALLOW));
+        userDecisions.saveForApplication(file, UserDecision.of(decisionKey, DENY));
+        userDecisions.saveForDomain(file, UserDecision.of(decisionKey, ALLOW));
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
 
         // then
         assertThat(result, is(Optional.of(DENY)));
+    }
+
+    @Test
+    public void shouldNotReturnSavedValueOfOtherKey() throws Exception {
+        // given
+        final JNLPFile file = loadJnlpFile("/net/sourceforge/jnlp/basic.jnlp");
+
+        // when
+        userDecisions.saveForApplication(file, UserDecision.of(otherKey1, DENY));
+        userDecisions.saveForApplication(file, UserDecision.of(otherKey2, ALLOW));
+        userDecisions.saveForApplication(file, UserDecision.of(otherKey3, SANDBOX));
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
+
+        // then
+        assertThat(result, is(Optional.empty()));
     }
 
     @Test
@@ -113,8 +133,8 @@ public class UserDecisionsFileStoreTest {
         final JNLPFile otherFile = loadJnlpFile("/net/sourceforge/jnlp/launchApp.jnlp");
 
         // when
-        userDecisions.saveForApplication(otherFile, UserDecision.of(RUN_UNSIGNED_APPLICATION, DENY));
-        final Optional<AllowDeny> result = userDecisions.getUserDecisions(RUN_UNSIGNED_APPLICATION, file, AllowDeny.class);
+        userDecisions.saveForApplication(otherFile, UserDecision.of(decisionKey, DENY));
+        final Optional<AllowDeny> result = userDecisions.getUserDecisions(decisionKey, file, AllowDeny.class);
 
         // then
         assertThat(result, is(Optional.empty()));


### PR DESCRIPTION
The new JSON file has the following structure:

```
{
  "version": "1",
  "userDecisions": [
    {
      "domain": "http://localhost",
      "jarNames": [
        "eager.jar",
        "lazy.jar",
        "native.jar"
      ],
      "decisions": {
        "RUN_UNSIGNED_APPLICATION": "DENY",
        "RUN_MISSING_ALAC_APPLICATION": "ALLOW",
        "RUN_MISSING_PERMISSIONS_APPLICATION": "SANDBOX"
      }
    }
  ]
}
```

The advantage is that multiple decisions can be stored in the same entry.