### PR TITLE
Multiple eager parts

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/ApplicationTrustValidatorImpl.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/ApplicationTrustValidatorImpl.java
@@ -202,7 +202,10 @@ public class ApplicationTrustValidatorImpl implements ApplicationTrustValidator 
         final LoadableJar mainJar = jars.stream()
                 .filter(jar -> Objects.equals(jar.getJarDesc(), mainJarDesc))
                 .findFirst()
-                .orElseThrow(() -> new LaunchException("Main jar " + mainJarDesc + " not found in " + jars));
+                .orElseThrow(() -> {
+                    LOG.debug("Main jar {} not found in {}", mainJarDesc, jars);
+                    return new LaunchException("Could not find main jar among the eager jars");
+                });
         return toFile(mainJar).orElseThrow(() -> new LaunchException("Could not find/download main jar file."));
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
@@ -75,6 +75,7 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
             }
         }
         while (loadMoreJars(name, "findClass()"));
+        LOG.debug("Could not find class {}", name);
         throw new ClassNotFoundException(name);
     }
 
@@ -93,6 +94,7 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
             }
         }
         while (loadMoreJars(name, "findResource()"));
+        LOG.debug("Could not find resource {}", name);
         return null;
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
@@ -51,6 +51,7 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
     }
 
     private void addJar(LoadableJar jar) {
+        LOG.debug("add jar: {}", jar.jarDesc.getLocation());
         addJarLock.lock();
         try {
             jar.getLocation().ifPresent(location -> {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
@@ -44,9 +44,7 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
                 .count() > 0;
 
         if (result) {
-            if (reason != null) {
-                LOG.debug("loaded more jars because of {} for {}", reason, name);
-            }
+            LOG.debug("loaded more jars because of {} for {}", reason, name);
         }
 
         return result;
@@ -100,14 +98,6 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
 
     @Override
     public Enumeration<URL> findResources(final String name) throws IOException {
-        boolean hasLoaded = false;
-        while (loadMoreJars(name, null)) {
-            hasLoaded = true;
-            // continue until finished
-        }
-        if (hasLoaded) {
-            LOG.debug("", new Exception("loaded all jars because of call to findResources()"));
-        }
         return super.findResources(name);
     }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
@@ -45,7 +45,7 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
 
         if (result) {
             if (reason != null) {
-                LOG.debug("loaded more jars because of {}", reason);
+                LOG.debug("loaded more jars because of {} for {}", reason, name);
             }
         }
 

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoader.java
@@ -1,6 +1,7 @@
 package net.adoptopenjdk.icedteaweb.classloader;
 
 import net.adoptopenjdk.icedteaweb.jnlp.element.resource.JARDesc;
+import net.adoptopenjdk.icedteaweb.jnlp.version.VersionString;
 
 import java.io.IOException;
 import java.net.URL;
@@ -136,6 +137,12 @@ public class JnlpApplicationClassLoader extends URLClassLoader {
                     .add("location=" + location.map(URL::toString).orElse("--NOT FOUND IN CACHE--"))
                     .add("jarDesc=" + jarDesc)
                     .toString();
+        }
+
+        public String toLoggingString() {
+            final VersionString version = getJarDesc().getVersion();
+            final URL location = getJarDesc().getLocation();
+            return version != null ? location +"(v:" + version + ")" : location.toString();
         }
     }
 }

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/PartsHandler.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/PartsHandler.java
@@ -122,12 +122,22 @@ public class PartsHandler implements JarProvider, PartsCache {
                 return Collections.emptyList();
             }
 
-            final Part next = notLoaded.stream()
+            final Optional<Part> supportingPart = notLoaded.stream()
                     .filter(part -> part.supports(resourceName))
-                    .findFirst()
-                    .orElse(notLoaded.get(0));
+                    .findFirst();
 
-            return loadLazyPart(next);
+            if (supportingPart.isPresent()) {
+                return loadLazyPart(supportingPart.get());
+            }
+
+            final Optional<Part> genericPart = notLoaded.stream()
+                    .filter(part -> part.getPackages().isEmpty())
+                    .findFirst();
+
+            if (genericPart.isPresent()) {
+                return loadLazyPart(genericPart.get());
+            }
+            return Collections.emptyList();
         } finally {
             partsLock.unlock();
         }

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/PartsHandler.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/classloader/PartsHandler.java
@@ -93,12 +93,14 @@ public class PartsHandler implements JarProvider, PartsCache {
                 .collect(Collectors.toList())
         );
 
-        LOG.debug("failed to eager load the following jars: {}", result.stream()
+        final String failedToLoadJars = result.stream()
                 .filter(jar -> !jar.getLocation().isPresent())
                 .map(LoadableJar::toLoggingString)
                 .sorted()
-                .collect(Collectors.toList())
-        );
+                .collect(Collectors.joining(", "));
+        if (!StringUtils.isBlank(failedToLoadJars)) {
+            LOG.debug("failed to download the following jars: {}", failedToLoadJars);
+        }
 
         trustValidator.validateEagerJars(result);
         loadedByClassloaderParts.addAll(eagerParts);

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoaderTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/classloader/JnlpApplicationClassLoaderTest.java
@@ -118,7 +118,7 @@ public class JnlpApplicationClassLoaderTest {
         } catch (final Exception ignore) {}
 
         //than
-        assertEquals(1, partsHandler.getDownloaded().size());
+        assertEquals(0, partsHandler.getDownloaded().size());
     }
 
     @Test

--- a/integration-tests/classloader-integration-tests/src/test/java/net/adoptopenjdk/icedteaweb/integration/classloader/BasicClassloaderIntegrationTests.java
+++ b/integration-tests/classloader-integration-tests/src/test/java/net/adoptopenjdk/icedteaweb/integration/classloader/BasicClassloaderIntegrationTests.java
@@ -105,7 +105,6 @@ public class BasicClassloaderIntegrationTests {
 
     /**
      * if recursive attribute is not defined only direct classes in the package of a part can be downloaded.
-     * Never the less the remaining parts are downloaded one by one in a trial and error approach to find the class.
      */
     @RepeatedTest(10)
     public void testLoadClassFromLazyJarWithoutRecursive() throws Exception {
@@ -114,13 +113,15 @@ public class BasicClassloaderIntegrationTests {
 
         //when
         final ClassLoader classLoader = createAndInitClassloader(partsHandler);
-        final Class<?> loadedClass = classLoader.loadClass(CLASS_A);
+        try {
+            classLoader.loadClass(CLASS_A);
+            Assertions.fail("should not have found the class");
+        } catch (ClassNotFoundException ignored) {
+        }
 
         //than
-        Assertions.assertNotNull(loadedClass);
-        Assertions.assertEquals(classLoader, loadedClass.getClassLoader());
-        Assertions.assertEquals(1, partsHandler.getDownloaded().size());
-        Assertions.assertTrue(partsHandler.hasTriedToDownload(JAR_1));
+        Assertions.assertEquals(0, partsHandler.getDownloaded().size());
+        Assertions.assertFalse(partsHandler.hasTriedToDownload(JAR_1));
     }
 
     /**


### PR DESCRIPTION
A JNLP file may have more than one eager part.
All the jars from all eager parts must be validated together.

This change ensures the above. The old implementation validated each eager part by itself.