### PR TITLE
Fixed EDT Classloading issues after EDT shutdown.

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/Launcher.java
+++ b/core/src/main/java/net/sourceforge/jnlp/Launcher.java
@@ -27,13 +27,14 @@ import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
 import net.adoptopenjdk.icedteaweb.resources.UpdatePolicy;
 import net.adoptopenjdk.icedteaweb.ui.swing.SwingUtils;
 import net.sourceforge.jnlp.config.DeploymentConfiguration;
+import net.sourceforge.jnlp.runtime.AppContextFactory;
 import net.sourceforge.jnlp.runtime.AppletInstance;
 import net.sourceforge.jnlp.runtime.ApplicationInstance;
-import net.sourceforge.jnlp.runtime.classloader.JNLPClassLoader;
 import net.sourceforge.jnlp.runtime.JNLPRuntime;
+import net.sourceforge.jnlp.runtime.classloader.DelegatingClassLoader;
+import net.sourceforge.jnlp.runtime.classloader.JNLPClassLoader;
 import net.sourceforge.jnlp.services.InstanceExistsException;
 import net.sourceforge.jnlp.services.ServiceUtil;
-import sun.awt.SunToolkit;
 
 import javax.swing.text.html.parser.ParserDelegator;
 import java.applet.Applet;
@@ -436,6 +437,9 @@ public class Launcher {
             }
         }
 
+        //inject classloader into edt delegating classloader
+        DelegatingClassLoader.getInstance().setClassLoader(classLoader);
+
     }
 
     /**
@@ -643,8 +647,7 @@ public class Launcher {
             try {
                 // Do not create new AppContext if we're using NetX and icedteaplugin.
                 // The plugin needs an AppContext too, but it has to be created earlier.
-                SunToolkit.createNewAppContext();
-
+                AppContextFactory.createNewAppContext();
                 doPerApplicationAppContextHacks();
 
                 if (file.isApplication()) {

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/AppContextFactory.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/AppContextFactory.java
@@ -8,13 +8,15 @@ public class AppContextFactory {
         //set temporary classloader for EventQueue initialization
         //already a call to AppContext.getAppContext(...) initializes the EventQueue.class
         ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
-        DelegatingClassLoader delegatingLoader = DelegatingClassLoader.getInstance();
-        delegatingLoader.setClassLoader(originalLoader);
+        try {
+            DelegatingClassLoader delegatingLoader = DelegatingClassLoader.getInstance();
+            delegatingLoader.setClassLoader(originalLoader);
 
-        Thread.currentThread().setContextClassLoader(delegatingLoader);
-
-        SunToolkit.createNewAppContext();
-        //restore original classloader
-        Thread.currentThread().setContextClassLoader(originalLoader);
+            Thread.currentThread().setContextClassLoader(delegatingLoader);
+            SunToolkit.createNewAppContext();
+        }finally {
+            //restore original classloader
+            Thread.currentThread().setContextClassLoader(originalLoader);
+        }
     }
 }

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/AppContextFactory.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/AppContextFactory.java
@@ -3,10 +3,8 @@ package net.sourceforge.jnlp.runtime;
 import net.sourceforge.jnlp.runtime.classloader.DelegatingClassLoader;
 import sun.awt.SunToolkit;
 
-public class AppContextFactory
-{
-    public static void createNewAppContext()
-    {
+public class AppContextFactory {
+    public static void createNewAppContext() {
         //set temporary classloader for EventQueue initialization
         //already a call to AppContext.getAppContext(...) initializes the EventQueue.class
         ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/AppContextFactory.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/AppContextFactory.java
@@ -1,0 +1,22 @@
+package net.sourceforge.jnlp.runtime;
+
+import net.sourceforge.jnlp.runtime.classloader.DelegatingClassLoader;
+import sun.awt.SunToolkit;
+
+public class AppContextFactory
+{
+    public static void createNewAppContext()
+    {
+        //set temporary classloader for EventQueue initialization
+        //already a call to AppContext.getAppContext(...) initializes the EventQueue.class
+        ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
+        DelegatingClassLoader delegatingLoader = DelegatingClassLoader.getInstance();
+        delegatingLoader.setClassLoader(originalLoader);
+
+        Thread.currentThread().setContextClassLoader(delegatingLoader);
+
+        SunToolkit.createNewAppContext();
+        //restore original classloader
+        Thread.currentThread().setContextClassLoader(originalLoader);
+    }
+}

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -1,0 +1,89 @@
+package net.sourceforge.jnlp.runtime.classloader;
+
+import java.net.URL;
+
+public class DelegatingClassLoader extends ClassLoader
+{
+    public static final DelegatingClassLoader instance = new DelegatingClassLoader(Thread.currentThread().getContextClassLoader());
+    private ClassLoader classLoader;
+
+    public static DelegatingClassLoader getInstance()
+    {
+        return instance;
+    }
+
+    DelegatingClassLoader(ClassLoader loader)
+    {
+        super(loader);
+        this.classLoader = loader;
+    }
+
+    public void setClassLoader(ClassLoader loader)
+    {
+        this.classLoader = loader;
+    }
+
+    protected Class findClass(String name) throws ClassNotFoundException
+    {
+        return this.classLoader.loadClass(name);
+    }
+
+    protected URL findResource(String name)
+    {
+        return this.classLoader.getResource(name);
+    }
+
+    public int hashCode()
+    {
+
+        int result = 1;
+        result = 31 * result + (this.classLoader == null ? 0 : this.classLoader.hashCode());
+        result = 31 * result + (this.getParent() == null ? 0 : this.getParent().hashCode());
+        return result;
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+        {
+            return true;
+        }
+        else if (obj == null)
+        {
+            return false;
+        }
+        else if (this.getClass() != obj.getClass())
+        {
+            return false;
+        }
+        else
+        {
+            DelegatingClassLoader other = (DelegatingClassLoader) obj;
+            if (this.classLoader == null)
+            {
+                if (other.classLoader != null)
+                {
+                    return false;
+                }
+            }
+            else if (!this.classLoader.equals(other.classLoader))
+            {
+                return false;
+            }
+
+            if (this.getParent() == null)
+            {
+                if (other.getParent() != null)
+                {
+                    return false;
+                }
+            }
+            else if (!this.getParent().equals(other.getParent()))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -19,8 +19,7 @@ public class DelegatingClassLoader extends ClassLoader {
     }
 
     public void setClassLoader(ClassLoader loader) {
-        Assert.requireNonNull(loader, "loader");
-        this.classLoader = loader;
+        this.classLoader = Assert.requireNonNull(loader, "loader");
     }
 
     protected Class findClass(String name) throws ClassNotFoundException {

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -1,5 +1,7 @@
 package net.sourceforge.jnlp.runtime.classloader;
 
+import net.adoptopenjdk.icedteaweb.Assert;
+
 import java.net.URL;
 import java.util.Objects;
 
@@ -13,10 +15,12 @@ public class DelegatingClassLoader extends ClassLoader {
 
     DelegatingClassLoader(ClassLoader loader) {
         super(loader);
+        Assert.requireNonNull(loader, "loader");
         this.classLoader = loader;
     }
 
     public void setClassLoader(ClassLoader loader) {
+        Assert.requireNonNull(loader, "loader");
         this.classLoader = loader;
     }
 

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -3,68 +3,54 @@ package net.sourceforge.jnlp.runtime.classloader;
 import java.net.URL;
 import java.util.Objects;
 
-public class DelegatingClassLoader extends ClassLoader
-{
+public class DelegatingClassLoader extends ClassLoader {
     public static final DelegatingClassLoader instance = new DelegatingClassLoader(Thread.currentThread().getContextClassLoader());
     private ClassLoader classLoader;
 
-    public static DelegatingClassLoader getInstance()
-    {
+    public static DelegatingClassLoader getInstance() {
         return instance;
     }
 
-    DelegatingClassLoader(ClassLoader loader)
-    {
+    DelegatingClassLoader(ClassLoader loader) {
         super(loader);
         this.classLoader = loader;
     }
 
-    public void setClassLoader(ClassLoader loader)
-    {
+    public void setClassLoader(ClassLoader loader) {
         this.classLoader = loader;
     }
 
-    protected Class findClass(String name) throws ClassNotFoundException
-    {
+    protected Class findClass(String name) throws ClassNotFoundException {
         return this.classLoader.loadClass(name);
     }
 
-    protected URL findResource(String name)
-    {
+    protected URL findResource(String name) {
         return this.classLoader.getResource(name);
     }
 
-    public int hashCode()
-    {
+    public int hashCode() {
         int result = 1;
         result = 31 * result + (this.classLoader == null ? 0 : this.classLoader.hashCode());
         result = 31 * result + (this.getParent() == null ? 0 : this.getParent().hashCode());
         return result;
     }
 
-    public boolean equals(Object obj)
-    {
-        if (this == obj)
-        {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        else if (obj == null)
-        {
+        else if (obj == null) {
             return false;
         }
-        else if (this.getClass() != obj.getClass())
-        {
+        else if (this.getClass() != obj.getClass()) {
             return false;
         }
-        else
-        {
+        else {
             DelegatingClassLoader other = (DelegatingClassLoader) obj;
-            if(Objects.equals(this.classLoader,other.classLoader)==false)
-            {
+            if(Objects.equals(this.classLoader,other.classLoader)==false) {
                 return false;
             }
-            if(Objects.equals(this.getParent(),other.getParent()) == false)
-            {
+            if(Objects.equals(this.getParent(),other.getParent()) == false) {
                 return false;
             }
             return true;

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -50,7 +50,7 @@ public class DelegatingClassLoader extends ClassLoader {
             if(!Objects.equals(this.classLoader,other.classLoader)) {
                 return false;
             }
-            if(Objects.equals(this.getParent(),other.getParent()) == false) {
+            if(!Objects.equals(this.getParent(),other.getParent())) {
                 return false;
             }
             return true;

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -1,6 +1,7 @@
 package net.sourceforge.jnlp.runtime.classloader;
 
 import java.net.URL;
+import java.util.Objects;
 
 public class DelegatingClassLoader extends ClassLoader
 {
@@ -35,7 +36,6 @@ public class DelegatingClassLoader extends ClassLoader
 
     public int hashCode()
     {
-
         int result = 1;
         result = 31 * result + (this.classLoader == null ? 0 : this.classLoader.hashCode());
         result = 31 * result + (this.getParent() == null ? 0 : this.getParent().hashCode());
@@ -59,30 +59,14 @@ public class DelegatingClassLoader extends ClassLoader
         else
         {
             DelegatingClassLoader other = (DelegatingClassLoader) obj;
-            if (this.classLoader == null)
-            {
-                if (other.classLoader != null)
-                {
-                    return false;
-                }
-            }
-            else if (!this.classLoader.equals(other.classLoader))
+            if(Objects.equals(this.classLoader,other.classLoader)==false)
             {
                 return false;
             }
-
-            if (this.getParent() == null)
-            {
-                if (other.getParent() != null)
-                {
-                    return false;
-                }
-            }
-            else if (!this.getParent().equals(other.getParent()))
+            if(Objects.equals(this.getParent(),other.getParent()) == false)
             {
                 return false;
             }
-
             return true;
         }
     }

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/DelegatingClassLoader.java
@@ -14,8 +14,7 @@ public class DelegatingClassLoader extends ClassLoader {
     }
 
     private DelegatingClassLoader(ClassLoader loader) {
-        super(loader);
-        Assert.requireNonNull(loader, "loader");
+        super(Assert.requireNonNull(loader, "loader"));
         this.classLoader = loader;
     }
 


### PR DESCRIPTION
The EventQueue.class stores the classloader in a final field classLoader. The EventQueue itself is stored static inside SunToolkit.class. Even if the active EDT thread classloader is modified to a JNLP classloader, classloading will fail once an AWTAutoShutdown occurs. (No edt activity for 1 second). If any new activity starts, the EDT Thread is recreated and initialized with the classloader stored in field classLoader in EventQueue class. This was not the JNLP classloader anymore. The result are ClassNotFound Exceptions. As there does not seem to be a "nice solution" because of the EventQueue implementation details the current solution temporary sets a DelegatingClassLoader to the thread which will initialize the eventqueue. Once initialized the original classloader is restored to the thread. During webstart loading the DelegatingClassLoader uses the original classloader once the jnlp classloader is active it gets injected into the DelegatingClassLoader. See:
https://github.com/karakun/OpenWebStart/issues/201