### PR TITLE
fix: JARs downloaded with URI-escaped characters don't get loaded

### DIFF
--- a/netx/net/sourceforge/jnlp/runtime/CachedJarFileCallback.java
+++ b/netx/net/sourceforge/jnlp/runtime/CachedJarFileCallback.java
@@ -43,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.AccessController;
@@ -103,9 +104,11 @@ final class CachedJarFileCallback implements URLJarFileCallBack {
 
         if (UrlUtils.isLocalFile(localUrl)) {
             // if it is known to us, just return the cached file
-            JarFile returnFile = new JarFile(localUrl.getPath());
+            JarFile returnFile=null;
             
             try {
+            	localUrl.toURI().getPath();
+            	returnFile = new JarFile(localUrl.toURI().getPath());
                 
                 // Blank out the class-path because:
                 // 1) Web Start does not support it
@@ -117,6 +120,8 @@ final class CachedJarFileCallback implements URLJarFileCallBack {
 
             } catch (NullPointerException npe) {
                 // Discard NPE here. Maybe there was no manifest, maybe there were no attributes, etc.
+			} catch (URISyntaxException e) {
+				// should not happen as localUrl was built using localFile.toURI().toURL(), see JNLPClassLoader.activateJars(List<JARDesc>)
             }
 
             return returnFile;

--- a/tests/netx/unit/net/sourceforge/jnlp/runtime/CachedJarFileCallbackTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/runtime/CachedJarFileCallbackTest.java
@@ -1,0 +1,55 @@
+package net.sourceforge.jnlp.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.jar.JarFile;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sourceforge.jnlp.util.FileTestUtils;
+import net.sourceforge.jnlp.util.FileUtils;
+
+public class CachedJarFileCallbackTest {
+	private File tempDirectory;
+
+	@Before
+	public void before() throws IOException {
+		tempDirectory = FileTestUtils.createTempDirectory();
+	}
+
+	@After
+	public void after() throws IOException {
+		FileUtils.recursiveDelete(tempDirectory, tempDirectory.getParentFile());
+	}
+
+	@Test
+	public void testRetrieve() throws Exception {
+		List<String> names = Arrays.asList("test1.0.jar", "test@1.0.jar");
+		
+		for (String name: names) {
+			// URL-encode the filename
+			name = URLEncoder.encode(name, StandardCharsets.UTF_8.name());
+			// create temp jar file
+			File jarFile = new File(tempDirectory, name);
+			FileTestUtils.createJarWithContents(jarFile /* no contents */);
+
+			// JNLPClassLoader.activateJars uses toUri().toURL() to get the local file URL
+			URL localUrl = jarFile.toURI().toURL();
+			URL remoteUrl = new URL("http://localhost/" + name);
+			// add jar to cache
+			CachedJarFileCallback cachedJarFileCallback = CachedJarFileCallback.getInstance();
+			cachedJarFileCallback.addMapping(remoteUrl, localUrl);
+			// retrieve from cache (throws exception if file not found)
+			try (JarFile fromCacheJarFile = cachedJarFileCallback.retrieve(remoteUrl)) {
+				// nothing to do, we just wanted to make sure that the local file existed
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #573