### PR TITLE
the path to user's desktop folder is read from windows registry

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/util/WindowsDesktopEntry.java
+++ b/core/src/main/java/net/sourceforge/jnlp/util/WindowsDesktopEntry.java
@@ -37,6 +37,8 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.swing.filechooser.FileSystemView;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.adoptopenjdk.icedteaweb.IcedTeaWebConstants.DOUBLE_QUOTE;
 import static net.sourceforge.jnlp.util.WindowsShortcutManager.getWindowsShortcutsFile;
@@ -235,8 +237,8 @@ public class WindowsDesktopEntry implements GenericDesktopEntry {
 				}
 			}
 		} catch (final Exception e) {
-			LOG.error("Could not retrieve path to client desktop folder from registry", e);
+			LOG.warn("Could not retrieve path to client desktop folder from registry", e);
 		}
-		return System.getenv("userprofile") + "/Desktop";
+		return FileSystemView.getFileSystemView().getHomeDirectory().getAbsolutePath() + "/Desktop"; 
 	}
 }

--- a/core/src/main/java/net/sourceforge/jnlp/util/WindowsDesktopEntry.java
+++ b/core/src/main/java/net/sourceforge/jnlp/util/WindowsDesktopEntry.java
@@ -19,6 +19,7 @@ import mslinks.ShellLink;
 import net.adoptopenjdk.icedteaweb.IcedTeaWebConstants;
 import net.adoptopenjdk.icedteaweb.LazyLoaded;
 import net.adoptopenjdk.icedteaweb.io.FileUtils;
+import net.adoptopenjdk.icedteaweb.io.IOUtils;
 import net.adoptopenjdk.icedteaweb.jvm.JvmUtils;
 import net.adoptopenjdk.icedteaweb.logging.Logger;
 import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
@@ -28,11 +29,13 @@ import net.sourceforge.jnlp.JNLPFile;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.MalformedInputException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.adoptopenjdk.icedteaweb.IcedTeaWebConstants.DOUBLE_QUOTE;
@@ -70,7 +73,7 @@ public class WindowsDesktopEntry implements GenericDesktopEntry {
     }
 
     private String getDesktopLnkPath() {
-        return System.getenv("userprofile") + "/Desktop/" + getShortcutFileName();
+        return desktopPath() + "/" + getShortcutFileName();
     }
 
     @Override
@@ -204,4 +207,36 @@ public class WindowsDesktopEntry implements GenericDesktopEntry {
     private String quoted(URL url) {
         return DOUBLE_QUOTE + url.toExternalForm() + DOUBLE_QUOTE;
     }
+    
+	private final static String desktopPath() {
+		final char QUOT = '"';
+		final String registryEntry = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders";
+		final String desktopProperty = "Desktop";
+
+		final ProcessBuilder pb = new ProcessBuilder("reg", "query", QUOT + registryEntry + QUOT, "/v",
+				QUOT + desktopProperty + QUOT);
+
+		try {
+			final Process p = pb.start();
+			p.waitFor(5, TimeUnit.SECONDS);
+			if (p.exitValue() == 0) {
+				try (final InputStream is = p.getInputStream()) {
+					final String output = IOUtils.readContentAsUtf8String(is);
+					if (output != null) {
+						final String typeName = "REG_SZ";
+						final int typeIndex = output.indexOf(typeName);
+						if (typeIndex != -1) {
+							final String desktopPath = output.substring(typeIndex + typeName.length());
+							if (desktopPath != null) {
+								return desktopPath.trim();
+							}
+						}
+					}
+				}
+			}
+		} catch (final Exception e) {
+			LOG.error("Could not retrieve path to client desktop folder from registry", e);
+		}
+		return System.getenv("userprofile") + "/Desktop";
+	}
 }


### PR DESCRIPTION
Currently the path to user's desktop folder is defined as 
```     
private String getDesktopLnkPath() {
        return System.getenv("userprofile") + "/Desktop/" + getShortcutFileName();
}
```
This is not always true.
It seems to be more reliable to get desktop path from windows registry
```     
HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders\Desktop
```
Current definition may be used as a fallback if registry read fails or is impossible for some reason.

This pull request will probably fix https://github.com/karakun/OpenWebStart/issues/243 issue.