### PR TITLE
Allow to specify require 32 bit JVM in JNLP file

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/resource/JREDesc.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/element/resource/JREDesc.java
@@ -47,6 +47,8 @@ public class JREDesc {
 
     public static final String VERSION_ATTRIBUTE = "version";
     public static final String VENDOR_ATTRIBUTE = "vendor";
+
+    public static final String REQUIRE_32_BIT_ATTRIBUTE = "require-32bit";
     public static final String HREF_ATTRIBUTE = "href";
     public static final String JAVA_VM_ARGS_ATTRIBUTE = "java-vm-args";
     public static final String INITIAL_HEAP_SIZE_ATTRIBUTE = "initial-heap-size";
@@ -59,6 +61,8 @@ public class JREDesc {
     private final VersionString version;
 
     private final String vendor;
+
+    private boolean require32Bit;
 
     /** the location of a JRE product or null */
     private final URL location;
@@ -75,11 +79,14 @@ public class JREDesc {
     /** list of ResourceDesc objects */
     private final List<ResourcesDesc> resources;
 
+
     /**
      * Create a JRE descriptor.
      *
      * @param version the platform version or the product version
      * if location is not null
+     * @param vendor the vendor
+     * @param require32Bit the hint whether this application requires a 32-bit JVM
      * @param location the location of a JRE product or null
      * @param vmArgs arguments to VM
      * @param initialHeapSize initial heap size
@@ -87,11 +94,12 @@ public class JREDesc {
      * @param resources list of ResourceDesc objects
      * @throws ParseException is something goes wrong
      */
-    public JREDesc(final VersionString version, final String vendor, final URL location,
+    public JREDesc(final VersionString version, final String vendor, final boolean require32Bit, final URL location,
                    final String vmArgs, final String initialHeapSize,
                    final String maximumHeapSize, final List<ResourcesDesc> resources) throws ParseException {
         this.version = version;
         this.vendor = vendor;
+        this.require32Bit = require32Bit;
         this.location = location;
         this.parsedArguments = parseArguments(vmArgs);
         this.initialHeapSize = checkHeapSize(initialHeapSize);
@@ -147,6 +155,10 @@ public class JREDesc {
      */
     public List<ResourcesDesc> getResourcesDesc() {
         return resources;
+    }
+
+    public boolean isRequire32Bit() {
+        return require32Bit;
     }
 
     /**

--- a/core/src/main/java/net/sourceforge/jnlp/Parser.java
+++ b/core/src/main/java/net/sourceforge/jnlp/Parser.java
@@ -502,11 +502,12 @@ public final class Parser {
             vmArgs = null;
         }
         final String vendor = getAttribute(node, JREDesc.VENDOR_ATTRIBUTE, null);
+        final boolean require32Bit = "true".equals(getAttribute(node, JREDesc.REQUIRE_32_BIT_ATTRIBUTE, "false"));
         final String initialHeap = getAttribute(node, JREDesc.INITIAL_HEAP_SIZE_ATTRIBUTE, null);
         final String maxHeap = getAttribute(node, JREDesc.MAX_HEAP_SIZE_ATTRIBUTE, null);
         final List<ResourcesDesc> resources = getResources(node, true);
 
-        return new JREDesc(version, vendor, location, vmArgs, initialHeap, maxHeap, resources);
+        return new JREDesc(version, vendor, require32Bit, location, vmArgs, initialHeap, maxHeap, resources);
     }
 
     private static void checkJreVersionWithSystemProperty(final VersionString version, final boolean strict) {

--- a/core/src/main/java/net/sourceforge/jnlp/Parser.java
+++ b/core/src/main/java/net/sourceforge/jnlp/Parser.java
@@ -72,6 +72,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.lang.Boolean.*;
 import static java.util.Arrays.asList;
 import static net.adoptopenjdk.icedteaweb.i18n.Translator.R;
 import static net.adoptopenjdk.icedteaweb.jnlp.element.application.AppletDesc.APPLET_DESC_ELEMENT;
@@ -502,7 +503,7 @@ public final class Parser {
             vmArgs = null;
         }
         final String vendor = getAttribute(node, JREDesc.VENDOR_ATTRIBUTE, null);
-        final boolean require32Bit = "true".equals(getAttribute(node, JREDesc.REQUIRE_32_BIT_ATTRIBUTE, "false"));
+        final boolean require32Bit = parseBoolean(getAttribute(node, JREDesc.REQUIRE_32_BIT_ATTRIBUTE, "false"));
         final String initialHeap = getAttribute(node, JREDesc.INITIAL_HEAP_SIZE_ATTRIBUTE, null);
         final String maxHeap = getAttribute(node, JREDesc.MAX_HEAP_SIZE_ATTRIBUTE, null);
         final List<ResourcesDesc> resources = getResources(node, true);
@@ -706,13 +707,13 @@ public final class Parser {
                 addInfo(informationDesc, child, getAttribute(child, IconDesc.KIND_ATTRIBUTE, IconKind.DEFAULT.getValue()), getIcon(child));
             }
             if (InformationDesc.OFFLINE_ALLOWED_ELEMENT.equals(name)) {
-                addInfo(informationDesc, child, null, Boolean.TRUE);
+                addInfo(informationDesc, child, null, TRUE);
             }
             if ("sharing-allowed".equals(name)) {
                 if (strict && !allowExtensions) {
                     throw new ParseException("sharing-allowed element is illegal in a standard JNLP file");
                 }
-                addInfo(informationDesc, child, null, Boolean.TRUE);
+                addInfo(informationDesc, child, null, TRUE);
             }
             if (ASSOCIATION_ELEMENT.equals(name)) {
                 addInfo(informationDesc, child, null, getAssociation(child));
@@ -1036,10 +1037,10 @@ public final class Parser {
     private ShortcutDesc getShortcut(final XmlNode node) throws ParseException {
 
         final String online = getAttribute(node, ONLINE_ATTRIBUTE, "true");
-        final boolean shortcutIsOnline = Boolean.valueOf(online);
+        final boolean shortcutIsOnline = valueOf(online);
 
         final String installAttribute = getAttribute(node, INSTALL_ATTRIBUTE, "false");
-        final boolean install = Boolean.valueOf(installAttribute);
+        final boolean install = valueOf(installAttribute);
 
         boolean showOnDesktop = false;
         MenuDesc menu = null;

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/jnlp/element/resource/JREDescTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/jnlp/element/resource/JREDescTest.java
@@ -45,50 +45,50 @@ public class JREDescTest {
 
     @Test
     public void testNulls() throws ParseException {
-        new JREDesc(null, null,null, null, null, null, null);
+        new JREDesc(null, null, false, null, null, null, null, null);
     }
 
     @Test
     public void testInitialHeapSize() throws ParseException {
-        new JREDesc(null, null,null, null, "1", null, null);
-        new JREDesc(null, null,null, null, "99999999", null, null);
-        new JREDesc(null, null,null, null, "1k", null, null);
-        new JREDesc(null, null,null, null, "1000k", null, null);
-        new JREDesc(null, null,null, null, "1K", null, null);
-        new JREDesc(null, null,null, null, "1000K", null, null);
-        new JREDesc(null, null,null, null, "1m", null, null);
-        new JREDesc(null, null,null, null, "1m", null, null);
-        new JREDesc(null, null,null, null, "1M", null, null);
-        new JREDesc(null, null,null, null, "1g", null, null);
-        new JREDesc(null, null,null, null, "1G", null, null);
-        new JREDesc(null, null,null, null, "10000G", null, null);
+        new JREDesc(null, null, false, null, null, "1", null, null);
+        new JREDesc(null, null, false, null, null, "99999999", null, null);
+        new JREDesc(null, null, false, null, null, "1k", null, null);
+        new JREDesc(null, null, false, null, null, "1000k", null, null);
+        new JREDesc(null, null, false, null, null, "1K", null, null);
+        new JREDesc(null, null, false, null, null, "1000K", null, null);
+        new JREDesc(null, null, false, null, null, "1m", null, null);
+        new JREDesc(null, null, false, null, null, "1m", null, null);
+        new JREDesc(null, null, false, null, null, "1M", null, null);
+        new JREDesc(null, null, false, null, null, "1g", null, null);
+        new JREDesc(null, null, false, null, null, "1G", null, null);
+        new JREDesc(null, null, false, null, null, "10000G", null, null);
     }
 
     @Test
     public void testMaximumHeapSize() throws ParseException {
-        new JREDesc(null, null,null, null, null, "1", null);
-        new JREDesc(null, null,null, null, null, "99999999", null);
-        new JREDesc(null, null,null, null, null, "1k", null);
-        new JREDesc(null, null,null, null, null, "1000k", null);
-        new JREDesc(null, null,null, null, null, "1K", null);
-        new JREDesc(null, null,null, null, null, "1000K", null);
-        new JREDesc(null, null,null, null, null, "1m", null);
-        new JREDesc(null, null,null, null, null, "1m", null);
-        new JREDesc(null, null,null, null, null, "1M", null);
-        new JREDesc(null, null,null, null, null, "1g", null);
-        new JREDesc(null, null,null, null, null, "1G", null);
-        new JREDesc(null, null,null, null, null, "10000G", null);
+        new JREDesc(null, null, false, null, null, null, "1", null);
+        new JREDesc(null, null, false, null, null, null, "99999999", null);
+        new JREDesc(null, null, false, null, null, null, "1k", null);
+        new JREDesc(null, null, false, null, null, null, "1000k", null);
+        new JREDesc(null, null, false, null, null, null, "1K", null);
+        new JREDesc(null, null, false, null, null, null, "1000K", null);
+        new JREDesc(null, null, false, null, null, null, "1m", null);
+        new JREDesc(null, null, false, null, null, null, "1m", null);
+        new JREDesc(null, null, false, null, null, null, "1M", null);
+        new JREDesc(null, null, false, null, null, null, "1g", null);
+        new JREDesc(null, null, false, null, null, null, "1G", null);
+        new JREDesc(null, null, false, null, null, null, "10000G", null);
     }
 
     @Test(expected = ParseException.class)
     public void testInitialHeapSizeBad() throws ParseException {
-        new JREDesc(null, null,null, null, "blah", null, null);
+        new JREDesc(null, null, false, null, null, "blah", null, null);
 
     }
 
     @Test(expected = ParseException.class)
     public void testMaximumHeapSizeBad() throws ParseException {
-        new JREDesc(null, null,null, null, null, "blah", null);
+        new JREDesc(null, null, false, null, null, null, "blah", null);
 
     }
 
@@ -133,7 +133,7 @@ public class JREDescTest {
 
     @Test
     public void parsingNoArguments() throws ParseException {
-        final JREDesc desc = new JREDesc(null, null,null, null, null, null, null);
+        final JREDesc desc = new JREDesc(null, null, false, null, null, null, null, null);
         final List<String> result = desc.getAllVmArgs();
 
         Assert.assertEquals(emptyList(), result);
@@ -141,7 +141,7 @@ public class JREDescTest {
 
     @Test
     public void parsingOnlyHeapArguments() throws ParseException {
-        final JREDesc desc = new JREDesc(null, null,null, null, "1k", "1m", null);
+        final JREDesc desc = new JREDesc(null, null, false, null, null, "1k", "1m", null);
         final List<String> result = desc.getAllVmArgs();
 
         Assert.assertEquals(Arrays.asList("-Xms1k", "-Xmx1m"), result);
@@ -149,7 +149,7 @@ public class JREDescTest {
 
     @Test
     public void parsingUnquotedArguments() throws ParseException {
-        final JREDesc desc = new JREDesc(null, null,null, "  some arguments \t\n without   quotes  ", null, null, null);
+        final JREDesc desc = new JREDesc(null, null, false, null, "  some arguments \t\n without   quotes  ", null, null, null);
         final List<String> result = desc.getAllVmArgs();
 
         Assert.assertEquals(Arrays.asList("some", "arguments", "without", "quotes"), result);
@@ -157,7 +157,7 @@ public class JREDescTest {
 
     @Test
     public void parsingQuotedArguments() throws ParseException {
-        final JREDesc desc = new JREDesc(null, null,null, "  some arguments \t\n \"with   Quotes\"  ", null, null, null);
+        final JREDesc desc = new JREDesc(null, null, false, null, "  some arguments \t\n \"with   Quotes\"  ", null, null, null);
         final List<String> result = desc.getAllVmArgs();
 
         Assert.assertEquals(Arrays.asList("some", "arguments", "with   Quotes"), result);
@@ -165,6 +165,6 @@ public class JREDescTest {
 
     @Test(expected = ParseException.class)
     public void parsingWrongQuotedArguments() throws ParseException {
-        new JREDesc(null, null,null, "  some arguments \"with   Quotes\"AndMissingSpace after quote  ", null, null, null);
+        new JREDesc(null, null, false, null, "  some arguments \"with   Quotes\"AndMissingSpace after quote  ", null, null, null);
     }
 }

--- a/core/src/test/java/net/sourceforge/jnlp/ParserTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/ParserTest.java
@@ -1940,4 +1940,57 @@ public class ParserTest extends NoStdOutErrTest {
         Assert.assertEquals(1, vendors.size());
         Assert.assertEquals(null, vendors.get(0));
     }
+
+    @Test
+    public void testJ2seRequire32bit() throws Exception {
+        String data = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<jnlp spec=\"1.0+\" codebase=\"http://someNotExistingUrl.com\" href=\"dummy.jnlp\">" +
+                "<information><offline-allowed/></information>" +
+                "<security><all-permissions/></security>" +
+                "<resources>" +
+                "<j2se version=\"1.8+\" require-32bit=\"true\"/>" +
+                "<jar href=\"dummy.jar\"/>" +
+                "</resources>" +
+                "<application-desc main-class=\"com.karakun.DummyMain\"/>" +
+                "</jnlp>";
+
+        final XMLParser defaultXmlParser = XmlParserFactory.getParser(defaultParser.getParserType());
+        XmlNode root = defaultXmlParser.getRootNode(new ByteArrayInputStream(data.getBytes()));
+        MockJNLPFile file = new MockJNLPFile(LANG_LOCALE);
+        Parser parser = new Parser(file, null, root, defaultParser, null);
+        final List<ResourcesDesc> resources = parser.getResources(root, false);
+        final List<Boolean> require32BitHints = resources.stream().flatMap(r -> Stream.of(r.getJREs()))
+                .map(jreDesc -> jreDesc.isRequire32Bit())
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(1, require32BitHints.size());
+        Assert.assertEquals(true, require32BitHints.get(0));
+    }
+
+    @Test
+    public void testJ2seNoRequire32bit() throws Exception {
+        String data = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<jnlp spec=\"1.0+\" codebase=\"http://someNotExistingUrl.com\" href=\"dummy.jnlp\">" +
+                "<information><offline-allowed/></information>" +
+                "<security><all-permissions/></security>" +
+                "<resources>" +
+                "<j2se version=\"1.8+\"/>" +
+                "<jar href=\"dummy.jar\"/>" +
+                "</resources>" +
+                "<application-desc main-class=\"com.karakun.DummyMain\"/>" +
+                "</jnlp>";
+
+        final XMLParser defaultXmlParser = XmlParserFactory.getParser(defaultParser.getParserType());
+        XmlNode root = defaultXmlParser.getRootNode(new ByteArrayInputStream(data.getBytes()));
+        MockJNLPFile file = new MockJNLPFile(LANG_LOCALE);
+        Parser parser = new Parser(file, null, root, defaultParser, null);
+        final List<ResourcesDesc> resources = parser.getResources(root, false);
+        final List<Boolean> require32BitHints = resources.stream().flatMap(r -> Stream.of(r.getJREs()))
+                .map(jreDesc -> jreDesc.isRequire32Bit())
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(1, require32BitHints.size());
+        Assert.assertEquals(false, require32BitHints.get(0));
+    }
+
 }


### PR DESCRIPTION
Provide an attribute to be able to implement logic to use a 32 bit JVM on a 64 bit Windows machine