### PR TITLE
Fixing issue 782 -> Exception about duplicate class definition during…

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoader.java
@@ -1432,12 +1432,13 @@ public class JNLPClassLoader extends URLClassLoader {
     @Override
     public Class<?> loadClass(final String name) throws ClassNotFoundException {
         final List<ExceptionalSupplier<Class<?>, ClassNotFoundException>> list = new ArrayList<>();
-        list.add(() -> findLoadedClassAll(name));
-        list.add(() -> loadClassFromParentClassloader(name));
-        list.add(() -> loadClassExt(name));
-        list.add(() -> loadClassFromInternalManifestClasspath(name));
-        list.add(() -> loadFromJarIndexes(name));
-
+        synchronized (getClassLoadingLock(name)) {
+            list.add(() -> findLoadedClassAll(name));
+            list.add(() -> loadClassFromParentClassloader(name));
+            list.add(() -> loadClassExt(name));
+            list.add(() -> loadClassFromInternalManifestClasspath(name));
+            list.add(() -> loadFromJarIndexes(name));
+        }
         return list.stream()
                 .map(ExceptionalSupplier::getResultOfCallOrNull)
                 .filter(Objects::nonNull)

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoader.java
@@ -1438,12 +1438,12 @@ public class JNLPClassLoader extends URLClassLoader {
             list.add(() -> loadClassExt(name));
             list.add(() -> loadClassFromInternalManifestClasspath(name));
             list.add(() -> loadFromJarIndexes(name));
+            return list.stream()
+                    .map(ExceptionalSupplier::getResultOfCallOrNull)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseThrow(() -> new ClassNotFoundException(name));
         }
-        return list.stream()
-                .map(ExceptionalSupplier::getResultOfCallOrNull)
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElseThrow(() -> new ClassNotFoundException(name));
     }
 
     private Class<?> loadClassFromParentClassloader(final String name) throws ClassNotFoundException {


### PR DESCRIPTION
Hi,

This is a fix for https://github.com/AdoptOpenJDK/IcedTea-Web/issues/782
It was already tested inside Volvo project and working fine.

Just adding thread synchronization on class loader, to prevent duplicate class loading issue.
Thread synchronization is made in same manner as in parent class java.lang.ClassLoader#loadClass(java.lang.String, boolean), so the loc it's per loaded class, and does not affect efficency.

Patryk
