### PR TITLE
Backport PR #438: AWTSecurityManager was removed

### DIFF
--- a/netx/net/sourceforge/jnlp/runtime/JNLPSecurityManager.java
+++ b/netx/net/sourceforge/jnlp/runtime/JNLPSecurityManager.java
@@ -29,7 +29,6 @@ import net.sourceforge.jnlp.services.ServiceUtil;
 import net.sourceforge.jnlp.util.logging.OutputController;
 import net.sourceforge.jnlp.util.WeakList;
 import net.sourceforge.swing.SwingUtils;
-import sun.awt.AWTSecurityManager;
 import sun.awt.AppContext;
 
 /**
@@ -47,7 +46,7 @@ import sun.awt.AppContext;
  * @author <a href="mailto:jmaxwell@users.sourceforge.net">Jon A. Maxwell (JAM)</a> - initial author
  * @version $Revision: 1.17 $
  */
-class JNLPSecurityManager extends AWTSecurityManager {
+class JNLPSecurityManager extends SecurityManager {
 
     // todo: some apps like JDiskReport can close the VM even when
     // an exit class is set - fix!
@@ -421,33 +420,6 @@ class JNLPSecurityManager extends AWTSecurityManager {
 
     protected void disableExit() {
         exitAllowed = false;
-    }
-
-    /**
-     * This returns the appropriate {@link AppContext}. Hooks in AppContext
-     * check if the current {@link SecurityManager} is an instance of
-     * AWTSecurityManager and if so, call this method to give it a chance to
-     * return the appropriate appContext based on the application that is
-     * running.
-     * <p>
-     * This can be called from any thread (possibly a swing thread) to find out
-     * the AppContext for the thread (which may correspond to a particular
-     * applet).
-     * </p>
-     */
-    @Override
-    public AppContext getAppContext() {
-        ApplicationInstance app = getApplication();
-        if (app == null) {
-            /*
-             * if we cannot find an application based on the code on the stack,
-             * then assume it is the main application
-             */
-            return mainAppContext;
-        } else {
-            return app.getAppContext();
-        }
-
     }
 
     /**


### PR DESCRIPTION
See Issue #437 

This is a trivial backport for the branch 1.8 to make icetea-web work on OpenJDK 13 to 17, tested on 15, 16, 17 EA.