### PR TITLE
Https client smart card

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Ville Skyttä <ville.skytta@iki.fi>
 Fridrich Strba <fridrich.strba@suse.com>
 Andrew Su <asu@redhat.com>
 Joshua Sumali <jsumali@redhat.com>
+David Tavoularis <david.tavoularis@mycom-osi.com>
 Joel Tesdall <jtesdall@mapcon.com>
 Michal Vala <mvala@redhat.com>
 Jiri Vanek <jvanek@redhat.com>

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/ClientCertSelectionPane.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/ClientCertSelectionPane.java
@@ -1,0 +1,240 @@
+package net.adoptopenjdk.icedteaweb.client.parts.dialogs.security;
+
+/* ClientCertSelectionPane.java -- requests client cert selection from users
+
+This file is part of IcedTea.
+
+IcedTea is free software; you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, version 2.
+
+IcedTea is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+IcedTea; see the file COPYING. If not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA.
+
+Linking this library statically or dynamically with other modules is making a
+combined work based on this library. Thus, the terms and conditions of the GNU
+General Public License cover the whole combination.
+
+As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent modules, and
+to copy and distribute the resulting executable under terms of your choice,
+provided that you also meet, for each linked independent module, the terms and
+conditions of the license of that module. An independent module is a module
+which is not derived from or based on this library. If you modify this library,
+you may extend this exception to your version of the library, but you are not
+obligated to do so. If you do not wish to do so, delete this exception
+statement from your version. */
+
+import net.adoptopenjdk.icedteaweb.ui.swing.dialogresults.DialogResult;
+import net.sourceforge.jnlp.security.SecurityUtil;
+
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
+
+import java.awt.BorderLayout;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+import static net.adoptopenjdk.icedteaweb.i18n.Translator.R;
+
+/**
+ * Modal non-minimizable dialog to request client cert selection
+ */
+public class ClientCertSelectionPane extends SecurityDialogPanel {
+
+ public ClientCertSelectionPane(SecurityDialog parent, Object[] extras) {
+     super(parent);
+     setLayout(new GridBagLayout());
+     JLabel jlInfo = new JLabel("<html>" + R("CVCertificateViewer")  + "</html>");
+
+     @SuppressWarnings("unchecked") LinkedHashMap<String, X509Certificate> aliasesMap = (LinkedHashMap<String, X509Certificate>)extras[0];
+     ArrayList<String> displayedNames = new ArrayList<String>();
+     for (Entry<String, X509Certificate> entry : aliasesMap.entrySet()) {
+        String subject = SecurityUtil.getCN(entry.getValue().getSubjectX500Principal().getName());
+        String issuer = SecurityUtil.getCN(entry.getValue().getIssuerX500Principal().getName());
+        int pos = entry.getKey().lastIndexOf(" (from ");
+        String source = (pos!=-1)?entry.getKey().substring(pos):"";
+        displayedNames.add(subject + ":" + issuer + source);
+     }
+     
+     JList<String> jlist = new JList<String>(displayedNames.toArray(new String[0]));
+     jlist.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+     jlist.setSelectedIndex(0);
+     JScrollPane scrollPane = new JScrollPane(jlist);
+
+     JButton jbOK = new JButton(R("ButOk"));
+     JButton jbCancel = new JButton(R("ButCancel"));
+     jbOK.setPreferredSize(jbCancel.getPreferredSize());
+     JButton jbDetails = new JButton(R("ButShowDetails"));
+     jbDetails.setBorderPainted(false);
+     jbDetails.setContentAreaFilled(false);
+     jbDetails.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+     jbDetails.setMargin(new Insets(0, 0, 0, 0));
+
+     GridBagConstraints c = new GridBagConstraints();
+     c.anchor = GridBagConstraints.NORTHWEST;
+     c.gridx = 0;
+     c.gridy = 0;
+     c.weightx = 1.0;
+     c.insets = new Insets(10, 5, 3, 3);
+     add(jlInfo, c);
+
+     c = new GridBagConstraints();
+     c.fill = GridBagConstraints.BOTH;
+     c.gridx = 0;
+     c.gridy = 1;
+     c.weightx = 1.0;
+     c.weighty = 1.0;
+     c.insets = new Insets(10, 5, 3, 3);
+     add(scrollPane, c);
+
+     c = new GridBagConstraints();
+     c.anchor = GridBagConstraints.SOUTHEAST;
+     c.gridx = 0;
+     c.gridy = 2;
+     c.weightx = 1.0;
+     c.insets = new Insets(5, 5, 3, 3);
+     add(jbDetails, c);
+     
+     c = new GridBagConstraints();
+     c.anchor = GridBagConstraints.SOUTHEAST;
+     c.gridx = 0;
+     c.gridy = 3;
+     c.weightx = 1.0;
+     c.insets = new Insets(3, 3, 10, 10);
+     
+     JPanel okCancelPane = new JPanel(new FlowLayout(FlowLayout.TRAILING, 0, 0));
+     okCancelPane.add(jbOK);
+     okCancelPane.add(Box.createHorizontalStrut(10));
+     okCancelPane.add(jbCancel);
+     add(okCancelPane, c);
+     
+     if (parent!=null) {
+         parent.getViwableDialog().setMinimumSize(new Dimension(500, 300));
+         parent.getViwableDialog().setLocationRelativeTo(null);
+         parent.getViwableDialog().pack();
+     }
+
+     initialFocusComponent = scrollPane;
+
+     // click on OK
+     jbOK.addActionListener(new ActionListener() {
+         @Override public void actionPerformed(ActionEvent e) {
+             certSelected(parent, jlist);
+         }
+     });
+     // double-click on selection
+     jlist.addMouseListener(new MouseAdapter() {
+         @Override public void mouseClicked(MouseEvent me) {
+             if (me.getClickCount() == 2)
+                 certSelected(parent, jlist);
+         }
+     });
+     // enter on selection
+     jlist.addKeyListener(new KeyAdapter() {
+         @Override public void keyReleased(KeyEvent ke) {
+             if(ke.getKeyCode() == KeyEvent.VK_ENTER)
+                 certSelected(parent, jlist);
+         }
+     });
+     // open certificate details
+     jbDetails.addActionListener(new ActionListener() {
+         @Override public void actionPerformed(ActionEvent e) {
+             SecurityDialog.showSingleCertInfoDialog(aliasesMap.values().toArray(new X509Certificate[0])[jlist.getSelectedIndex()],
+                 ClientCertSelectionPane.this);
+         }
+     });
+     // click on Cancel
+     jbCancel.addActionListener(new ActionListener() {
+         @Override public void actionPerformed(ActionEvent e) {
+             parent.setValue(null);
+             parent.getViwableDialog().dispose();
+         }
+     });
+ }
+
+ @Override
+ public DialogResult getDefaultNegativeAnswer() {
+     return null;
+ }
+
+ @Override
+ public DialogResult getDefaultPositiveAnswer() {
+     return null;
+ }
+
+ @Override
+ public DialogResult readFromStdIn(String what) {
+     return null;
+ }
+
+ @Override
+ public String helpToStdIn() {
+     return "";
+ }
+ 
+ private void certSelected(SecurityDialog parent, JList<String> jlist) {
+     parent.setValue(new DialogResult() {
+         @Override public int getButtonIndex() {
+            return jlist.getSelectedIndex();
+         }
+         @Override public boolean toBoolean() {
+            throw new UnsupportedOperationException("Not supported yet.");
+         }
+         @Override public String writeValue() {
+            throw new UnsupportedOperationException("Not supported yet.");
+         }                
+       });
+     parent.getViwableDialog().dispose();
+ }
+
+ public static void main(String[] args) throws Exception {
+     KeyStore ks = KeyStore.getInstance("Windows-MY");
+     ks.load(null, null);
+     Enumeration<String >aliases = ks.aliases();
+     LinkedHashMap<String, X509Certificate> aliasesMap = new LinkedHashMap<String, X509Certificate>();
+     while (aliases.hasMoreElements()) {
+         String alias = aliases.nextElement();
+         Certificate c = ks.getCertificate(alias);
+         if (c instanceof X509Certificate)
+            aliasesMap.put(alias + " (from browser keystore)", (X509Certificate)c);
+     }
+     JFrame f = new JFrame();
+     f.setMinimumSize(new Dimension(500, 300));
+     f.setSize(700, 300);
+     f.add(new ClientCertSelectionPane(null, new Object[] { aliasesMap }), BorderLayout.CENTER);
+     f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+     f.pack();
+     f.setVisible(true);
+ }
+}

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialog.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialog.java
@@ -98,8 +98,8 @@ public class SecurityDialog {
     private boolean requiresSignedJNLPWarning;
 
     SecurityDialog(SecurityDialogs.DialogType dialogType, AccessType accessType,
-                   JNLPFile file, CertVerifier JarCertVerifier, X509Certificate cert, Object[] extras) {
-        this.viwableDialog = new ViwableDialog();
+                   JNLPFile file, CertVerifier JarCertVerifier, X509Certificate cert, Object[] extras, boolean showInTaskBar) {
+        this.viwableDialog = new ViwableDialog(showInTaskBar);
         this.dialogType = dialogType;
         this.accessType = accessType;
         this.file = file;
@@ -114,6 +114,11 @@ public class SecurityDialog {
         initDialog();
     }
 
+    SecurityDialog(SecurityDialogs.DialogType dialogType, AccessType accessType,
+        JNLPFile file, CertVerifier JarCertVerifier, X509Certificate cert, Object[] extras) {
+       this(dialogType, accessType, file, JarCertVerifier, cert, extras, false);
+    }
+    
     /**
      * Construct a SecurityDialog to display some sort of access warning
      */
@@ -204,7 +209,7 @@ public class SecurityDialog {
      * @param parent the parent pane.
      */
     public static void showSingleCertInfoDialog(X509Certificate c,
-                        Window parent) {
+                        Component parent) {
         SecurityDialog dialog = new SecurityDialog(SecurityDialogs.DialogType.SINGLE_CERT_INFO, c);
         dialog.getViwableDialog().setLocationRelativeTo(parent);
         dialog.getViwableDialog().setModalityType(ModalityType.APPLICATION_MODAL);
@@ -281,7 +286,7 @@ public class SecurityDialog {
             dialogTitle = "Applet Warning";
         else if (dtype == SecurityDialogs.DialogType.PARTIALLY_SIGNED_WARNING)
             dialogTitle = "Security Warning";
-        else if (dtype == SecurityDialogs.DialogType.AUTHENTICATION)
+        else if (dtype == SecurityDialogs.DialogType.AUTHENTICATION || dtype == SecurityDialogs.DialogType.CLIENT_CERT_SELECTION)
             dialogTitle = "Authentication Required";
         return dialogTitle;
     }
@@ -336,6 +341,8 @@ public class SecurityDialog {
             lpanel = AppTrustWarningDialog.unsigned(sd, sd.file); // Only necessary for applets on 'high security' or above
         } else if (type == SecurityDialogs.DialogType.AUTHENTICATION) {
             lpanel = new PasswordAuthenticationPane(sd, sd.extras);
+        } else if (type == SecurityDialogs.DialogType.CLIENT_CERT_SELECTION) {
+           lpanel = new ClientCertSelectionPane(sd, sd.extras);
         } else if (type == SecurityDialogs.DialogType.UNSIGNED_EAS_NO_PERMISSIONS_WARNING) {
             lpanel = new MissingPermissionsAttributePanel(sd, sd.file.getTitle(), sd.file.getNotNullProbableCodeBase().toExternalForm());
         } else if (type == SecurityDialogs.DialogType.MISSING_ALACA) {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogMessage.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogMessage.java
@@ -81,5 +81,6 @@ public final class SecurityDialogMessage {
     public Semaphore lock;
     //if dialog slip out of awt thread, fake modal dialog is created. This is keeping it.
     public JDialog toDispose;
+    public boolean showInTaskBar;
 
 }

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogMessageHandler.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogMessageHandler.java
@@ -110,7 +110,7 @@ public class SecurityDialogMessageHandler implements Runnable {
     protected void handleMessage(final SecurityDialogMessage message) {
 
         final SecurityDialog dialog = new SecurityDialog(message.dialogType,
-                message.accessType, message.file, message.certVerifier, message.certificate, message.extras);
+                message.accessType, message.file, message.certVerifier, message.certificate, message.extras, message.showInTaskBar);
 
         if (processAutomatedAnswers(message, dialog)){
             return;

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogs.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogs.java
@@ -51,6 +51,8 @@ import net.sourceforge.jnlp.security.CertVerifier;
 import net.sourceforge.jnlp.util.UrlUtils;
 
 import javax.swing.JDialog;
+
+import java.awt.Dialog;
 import java.awt.Dialog.ModalityType;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -58,6 +60,8 @@ import java.net.NetPermission;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.cert.X509Certificate;
+import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 
@@ -92,6 +96,7 @@ public class SecurityDialogs {
         UNSIGNED_WARNING, /* requires confirmation with 'high-security' setting */
         APPLET_WARNING,
         AUTHENTICATION,
+        CLIENT_CERT_SELECTION,
         UNSIGNED_EAS_NO_PERMISSIONS_WARNING, /* when Extended applet security is at High Security and no permission attribute is find, */
         MISSING_ALACA, /*alaca - Application-Library-Allowable-Codebase Attribute*/
         MATCHING_ALACA,
@@ -203,7 +208,6 @@ public class SecurityDialogs {
      * permissions.
      */
     public static NamePassword showAuthenticationPrompt(String host, int port, String prompt, String type) {
-        LOG.debug("Showing dialog for basic auth for {}:{} with name {} of type {}", host, port, prompt, type);
 
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
@@ -218,7 +222,20 @@ public class SecurityDialogs {
         message.extras = new Object[]{host, port, prompt, type};
 
         DialogResult response = getUserResponse(message);
+        LOG.debug("Decided action for matching alaca at  was {}", response);
         return (NamePassword) response;
+    }
+    
+    public static DialogResult showClientCertSelectionPrompt(LinkedHashMap<String, X509Certificate> aliases) {
+
+       final SecurityDialogMessage message = new SecurityDialogMessage(null);
+       message.dialogType = DialogType.CLIENT_CERT_SELECTION;
+       message.extras = new Object[] {aliases};
+       message.showInTaskBar = true;
+
+       DialogResult response = getUserResponse(message);
+       LOG.debug("Decided action for selecting client certificate was {}", response);
+       return response;
     }
 
     public static boolean showMissingALACAttributePanel(JNLPFile file, URL codeBase, Set<URL> remoteUrls) {

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/ViwableDialog.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/ViwableDialog.java
@@ -57,13 +57,15 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ViwableDialog {
 
     private JDialog jd = null;
+    private boolean showInTaskBar;
     List<Runnable> operations = new ArrayList<Runnable>();
 
-    public ViwableDialog() {
+    public ViwableDialog(boolean showInTaskBar) {
+        this.showInTaskBar = showInTaskBar;
     }
 
     private JDialog createJDialog() {
-        jd = new JDialog();
+        jd = showInTaskBar?new JDialog((Dialog)null):new JDialog();
         jd.setName("ViwableDialog");
         SwingUtils.info(jd);
         jd.setIconImages(ImageResources.INSTANCE.getApplicationImages());

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/resources/ResourceTracker.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/resources/ResourceTracker.java
@@ -21,6 +21,7 @@ import net.adoptopenjdk.icedteaweb.jnlp.version.VersionString;
 import net.adoptopenjdk.icedteaweb.logging.Logger;
 import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
 import net.adoptopenjdk.icedteaweb.resources.CachedDaemonThreadPoolProvider.DaemonThreadFactory;
+import net.adoptopenjdk.icedteaweb.resources.Resource.Status;
 import net.sourceforge.jnlp.DownloadOptions;
 import net.sourceforge.jnlp.cache.CacheUtil;
 import net.sourceforge.jnlp.config.ConfigurationConstants;
@@ -396,6 +397,9 @@ public class ResourceTracker {
             LOG.debug("Download done. Shutting down executor");
             downloadExecutor.shutdownNow();
         }
+        
+        if (resources.length == 1 && resources[0].isSet(Status.ERROR))
+            throw new RuntimeException("Error while downloading initial resource " + resources[0]);
     }
 
     private Future<Resource> triggerDownloadFor(Resource resource, final Executor downloadExecutor) {

--- a/core/src/main/java/net/sourceforge/jnlp/cache/CacheUtil.java
+++ b/core/src/main/java/net/sourceforge/jnlp/cache/CacheUtil.java
@@ -234,6 +234,8 @@ public class CacheUtil {
      * @param title           name of the download
      */
     public static void waitForResources(final JNLPClassLoader jnlpClassLoader, final ResourceTracker tracker, final URL[] resources, final String title) {
+       // download first initial jar : so in case of client certificate, only 1 https client handshake is done 
+        boolean downloadInitialJarFirst = resources.length > 1 && resources[0].getProtocol().equals("https");
         try {
             final DownloadIndicator indicator = Optional.ofNullable(JNLPRuntime.getDefaultDownloadIndicator())
                     .orElseGet(() -> new DummyDownloadIndicator());
@@ -242,12 +244,17 @@ public class CacheUtil {
                 for (URL url : resources) {
                     tracker.addDownloadListener(url, resources, listener);
                 }
+                if (downloadInitialJarFirst)
+                    tracker.waitForResources(resources[0]);
+                // download all remaining ones
                 tracker.waitForResources(resources);
             } finally {
                 indicator.disposeListener(listener);
             }
         } catch (Exception ex) {
             LOG.error("Downloading of resources ended with error", ex);
+            if (downloadInitialJarFirst)
+               throw new RuntimeException(ex);
         }
     }
 

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
@@ -35,8 +35,6 @@ import net.sourceforge.jnlp.config.ConfigurationConstants;
 import net.sourceforge.jnlp.config.DeploymentConfiguration;
 import net.sourceforge.jnlp.config.PathsAndFiles;
 import net.sourceforge.jnlp.security.JNLPAuthenticator;
-import net.sourceforge.jnlp.security.KeyStores;
-import net.sourceforge.jnlp.security.SecurityUtil;
 import net.sourceforge.jnlp.services.XServiceManagerStub;
 import net.sourceforge.jnlp.util.RestrictedFileUtils;
 import net.sourceforge.jnlp.util.logging.LogConfig;
@@ -46,7 +44,7 @@ import sun.net.www.protocol.jar.URLJarFile;
 import javax.jnlp.ServiceManager;
 import javax.naming.ConfigurationException;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -70,7 +68,6 @@ import java.net.UnknownHostException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.security.AllPermission;
-import java.security.KeyStore;
 import java.security.Policy;
 import java.security.Security;
 import java.text.DateFormat;
@@ -272,13 +269,9 @@ public class JNLPRuntime {
         try {
             SSLSocketFactory sslSocketFactory;
             SSLContext context = SSLContext.getInstance("SSL");
-            KeyStore ks = KeyStores.getKeyStore(KeyStores.Level.USER, KeyStores.Type.CLIENT_CERTS).getKs();
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-            SecurityUtil.initKeyManagerFactory(kmf, ks);
             TrustManager[] trust = new TrustManager[] { getSSLSocketTrustManager() };
-            context.init(kmf.getKeyManagers(), trust, null);
+            context.init(new KeyManager[] { new MergedKeyManager() }, trust, null);
             sslSocketFactory = context.getSocketFactory();
-
             HttpsURLConnection.setDefaultSSLSocketFactory(sslSocketFactory);
         } catch (Exception e) {
             LOG.error("Unable to set SSLSocketfactory (may _prevent_ access to sites that should be trusted)! Continuing anyway...", e);

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/MergedKeyManager.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/MergedKeyManager.java
@@ -1,0 +1,287 @@
+package net.sourceforge.jnlp.runtime;
+
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509KeyManager;
+
+import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.SecurityDialogs;
+import net.adoptopenjdk.icedteaweb.logging.Logger;
+import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
+import net.adoptopenjdk.icedteaweb.ui.swing.dialogresults.DialogResult;
+import net.sourceforge.jnlp.security.KeyStores;
+import net.sourceforge.jnlp.security.SecurityUtil;
+
+public class MergedKeyManager extends X509ExtendedKeyManager
+{
+  private final static Logger LOG = LoggerFactory.getLogger(MergedKeyManager.class);
+  private static Map<String, String> hostToClientAliasCache = new ConcurrentHashMap<String, String>();
+  private X509KeyManager browserKeyManager;
+  private X509KeyManager userKeyManager;
+  private X509KeyManager systemKeyManager;
+  private final static String USER_SUFFIX = " (from user keystore)";
+  private final static String SYSTEM_SUFFIX = " (from system keystore)";
+  private final static String BROWSER_SUFFIX = " (from browser keystore)";
+  private static boolean userCancelled = false;
+   
+  MergedKeyManager() {
+    userKeyManager = getKeyManager(KeyStores.getKeyStore(KeyStores.Level.USER, KeyStores.Type.CLIENT_CERTS).getKs(), "SunX509");
+    systemKeyManager = getKeyManager(KeyStores.getKeyStore(KeyStores.Level.SYSTEM, KeyStores.Type.CLIENT_CERTS).getKs(), "SunX509");
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      try {
+        KeyStore ks = KeyStore.getInstance("Windows-MY");
+        ks.load(null, null);
+        browserKeyManager = getKeyManager(ks, "SunX509");
+      }
+      catch (Exception e) {
+        LOG.error("Unable to get browser keystore information", e);
+      }
+    }
+  }
+  
+  private X509KeyManager getKeyManager(KeyStore ks, String algo) {
+    try {
+      KeyManagerFactory kmf = KeyManagerFactory.getInstance(algo);
+      SecurityUtil.initKeyManagerFactory(kmf, ks);
+      KeyManager[] keyManagers = kmf.getKeyManagers();
+      if (keyManagers != null)
+         for (KeyManager keyManager : keyManagers)
+           if (keyManager instanceof X509KeyManager)
+             return (X509KeyManager)keyManager;
+    }
+    catch (Exception e) {
+      LOG.warn("Unable to get KeyStore " + ks, e);
+    }
+    return null;
+  }
+
+  @Override public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
+    if (userCancelled) {
+       LOG.warn("Client certificate selection previously cancelled by user, returning null alias");
+       return null;
+    }
+     
+    String host = getHostFromSocket(socket);
+    LOG.info("Retrieved host from socket : " + host);
+    if (host != null) {
+      String alias = hostToClientAliasCache.get(host.toLowerCase());
+      LOG.info("Found " + alias + " alias in cache for " + host.toLowerCase() + " and keyTypes " + Arrays.toString(keyTypes));
+      if (alias != null)
+        return alias;
+    }
+       
+    LinkedHashMap<String, X509Certificate> validClientAliases = new LinkedHashMap<>();
+    LinkedHashMap<String, X509Certificate> expiredClientAliases = new LinkedHashMap<>();
+    LinkedHashMap<String, X509Certificate> otherAliases = new LinkedHashMap<>();
+    for (String keyType : keyTypes) {
+      String[] aliasesWithSuffix = getClientAliases(keyType, issuers);
+      //if (aliasesWithSuffix != null)
+        for (String aliasWithSuffix : aliasesWithSuffix)
+        {
+          X509Certificate[] certs = getCertificateChain(removeAliasSuffix(aliasWithSuffix));
+          if (certs == null || certs.length == 0)
+            continue;
+          X509Certificate cert = certs[0];
+          try {
+            List<String> usage = cert.getExtendedKeyUsage();
+            // Extensions : 1.3.6.1.5.5.7.3.2=ClientCert 2.5.29.37.0=ANY 
+            if (usage != null && (usage.contains("1.3.6.1.5.5.7.3.2") || usage.contains("2.5.29.37.0"))) {
+              try {
+                cert.checkValidity();
+                LOG.info("Found valid client alias with clientCert or ANY extension: " + aliasWithSuffix);
+                validClientAliases.put(aliasWithSuffix, cert);
+              }
+              catch (CertificateException e) {
+                LOG.warn("Found expired client alias with clientCert or ANY extension: " + aliasWithSuffix);
+                expiredClientAliases.put(aliasWithSuffix, cert);
+              }
+            }
+            else {
+              LOG.warn("Found non-client alias: " + aliasWithSuffix);
+              otherAliases.put(aliasWithSuffix, cert);
+            }
+          }
+          catch (CertificateParsingException e) {
+            LOG.warn("Exception while getting ExtendedKeyUsage for alias " + aliasWithSuffix);
+            otherAliases.put(aliasWithSuffix, cert);
+          }
+      }
+    }
+    
+    String alias = null;
+    if (!validClientAliases.isEmpty())
+      alias = getPreferredAlias(validClientAliases, "valid client");
+    else {
+      expiredClientAliases.putAll(otherAliases);
+      if (!expiredClientAliases.isEmpty())
+        alias = getPreferredAlias(expiredClientAliases, "remaining");
+      else
+         LOG.warn("Could not find any client alias for keyTypes " + Arrays.toString(keyTypes));
+    }
+    
+    if (socket instanceof SSLSocket && host != null && alias != null) {
+      LOG.info("Added " + alias + " alias in cache for " + host.toLowerCase());
+      hostToClientAliasCache.put(host.toLowerCase(), alias);
+    }
+    return alias;
+  }
+
+  private String getHostFromSocket(Socket socket) {
+    try {
+      Class c = Class.forName("sun.security.ssl.SSLSocketImpl");
+      if (c.isInstance(socket)) {
+        Object o = c.cast(socket);
+        Method m = null;
+        try {
+          m = c.getDeclaredMethod("getHost", null);
+          m.setAccessible(true);
+        }
+        catch (NoSuchMethodException e) {
+          m = c.getDeclaredMethod("getPeerHost", null);
+        }
+        if (m != null)
+          return (String)m.invoke(o, null);
+      }
+    }
+    catch (Exception e) {
+      LOG.warn("Cannot get remote host from Socket", e);
+    }
+    return null;
+  }
+    
+  private String getPreferredAlias(LinkedHashMap<String, X509Certificate> aliasesMap, String aliasType) {
+    String alias = null;
+    if (aliasesMap.size() > 1) {
+      if (JNLPRuntime.isHeadless()) {
+         alias = aliasesMap.keySet().iterator().next();
+         LOG.info("Returning the first " + aliasType + " alias in headless mode : " + alias);
+      }
+      else {
+        DialogResult res = SecurityDialogs.showClientCertSelectionPrompt(aliasesMap);
+        if (res == null) {
+          userCancelled = true;
+          LOG.warn("Client certificate selection cancelled by user");
+        }
+        else {
+          alias = aliasesMap.keySet().toArray(new String[0])[res.getButtonIndex()];
+          LOG.info("Returning the selected " + aliasType + " alias : " + alias);
+        }
+      }
+    }
+    else if (aliasesMap.size() == 1) {
+      alias = aliasesMap.keySet().iterator().next();
+      LOG.info("Returning the only " + aliasType + " alias : " + alias);
+    }
+    return removeAliasSuffix(alias);
+  }
+  
+  private String removeAliasSuffix(String aliasWithSuffix) {
+     if (aliasWithSuffix.endsWith(USER_SUFFIX))
+        return aliasWithSuffix.substring(0, aliasWithSuffix.length() - USER_SUFFIX.length());
+     if (aliasWithSuffix.endsWith(SYSTEM_SUFFIX))
+        return aliasWithSuffix.substring(0, aliasWithSuffix.length() - SYSTEM_SUFFIX.length());
+     if (aliasWithSuffix.endsWith(BROWSER_SUFFIX))
+        return aliasWithSuffix.substring(0, aliasWithSuffix.length() - BROWSER_SUFFIX.length());
+     return aliasWithSuffix;
+  }
+  
+  public static String getAliasSuffix(String aliasWithSuffix) {
+     if (aliasWithSuffix.endsWith(USER_SUFFIX))
+        return USER_SUFFIX;
+     if (aliasWithSuffix.endsWith(SYSTEM_SUFFIX))
+        return SYSTEM_SUFFIX;
+     if (aliasWithSuffix.endsWith(BROWSER_SUFFIX))
+        return BROWSER_SUFFIX;
+     return null;
+  }
+
+  @Override public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+    String alias = null;
+    if (userKeyManager != null)
+      alias = userKeyManager.chooseServerAlias(keyType, issuers, socket);
+    if (alias == null && systemKeyManager != null)
+       alias = systemKeyManager.chooseServerAlias(keyType, issuers, socket);
+    if (alias == null && browserKeyManager != null)
+      alias = browserKeyManager.chooseServerAlias(keyType, issuers, socket);
+    return alias;
+  }
+
+  @Override public X509Certificate[] getCertificateChain(String alias) {
+    X509Certificate[] x509certificates = null;
+    if (userKeyManager != null)
+      x509certificates = userKeyManager.getCertificateChain(alias);
+    if (x509certificates == null && systemKeyManager != null)
+      x509certificates = systemKeyManager.getCertificateChain(alias);
+    if (x509certificates == null && browserKeyManager != null)
+      x509certificates = browserKeyManager.getCertificateChain(alias);
+    return x509certificates;
+  }
+
+  @Override public String[] getClientAliases(String keyType, Principal[] issuers) {
+    List<String> aliases = new ArrayList<String>();
+    if (userKeyManager != null)
+      addNonNullStrings(aliases, userKeyManager.getClientAliases(keyType, issuers), USER_SUFFIX);
+    if (systemKeyManager != null)
+      addNonNullStrings(aliases, systemKeyManager.getClientAliases(keyType, issuers), SYSTEM_SUFFIX);
+    if (browserKeyManager != null)
+      addNonNullStrings(aliases, browserKeyManager.getClientAliases(keyType, issuers), BROWSER_SUFFIX);
+    return aliases.toArray(new String[0]);
+  }
+
+  @Override public PrivateKey getPrivateKey(String alias) {
+    PrivateKey privateKey = null;
+    if (userKeyManager != null)
+      privateKey = userKeyManager.getPrivateKey(alias);
+    if (privateKey == null && systemKeyManager != null)
+      privateKey = systemKeyManager.getPrivateKey(alias);
+    if (privateKey == null && browserKeyManager != null)
+      privateKey = browserKeyManager.getPrivateKey(alias);
+    return privateKey;
+  }
+
+  @Override public String[] getServerAliases(String keyType, Principal[] issuers) {
+    List<String> aliases = new ArrayList<String>();
+    if (userKeyManager != null)
+      addNonNullStrings(aliases, userKeyManager.getServerAliases(keyType, issuers), null);
+    if (systemKeyManager != null)
+      addNonNullStrings(aliases, systemKeyManager.getServerAliases(keyType, issuers), null);
+    if (browserKeyManager != null)
+      addNonNullStrings(aliases, browserKeyManager.getServerAliases(keyType, issuers), null);
+    return aliases.toArray(new String[0]);
+  }
+  
+  @Override public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+    return chooseClientAlias(keyType, issuers, null);
+  }
+  
+  @Override public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+    return chooseServerAlias(keyType, issuers, null);
+  }
+  
+  private void addNonNullStrings(List<String> list, String[] array, String suffix) {
+    if (array != null)
+      for (String s : array)
+        if (s != null)
+          if (suffix != null)
+            list.add(s + suffix);
+          else
+            list.add(s);
+  }
+}

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoader.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoader.java
@@ -316,7 +316,8 @@ public class JNLPClassLoader extends URLClassLoader {
         strict = Boolean.parseBoolean(JNLPRuntime.getConfiguration().getProperty(ConfigurationConstants.KEY_STRICT_JNLP_CLASSLOADER));
 
         this.file = file;
-        this.tracker = new ResourceTracker(true, file.getDownloadOptions(), JNLPRuntime.getDefaultUpdatePolicy());
+        // no prefetch otherwise deployment.cache.parallelDownloadCount is not enforced
+        this.tracker = new ResourceTracker(false, file.getDownloadOptions(), JNLPRuntime.getDefaultUpdatePolicy());
         this.updatePolicy = policy;
         this.resources = file.getResources();
 
@@ -684,7 +685,6 @@ public class JNLPClassLoader extends URLClassLoader {
             if (jar.isEager() || jar.isMain()) {
                 initialJars.add(jar); // regardless of part
             }
-            // FIXME: this will trigger an eager download as the tracker is created with prefetch == true
             tracker.addResource(jar.getLocation(), jar.getVersion(),
                     jar.isCacheable() ? JNLPRuntime.getDefaultUpdatePolicy() : UpdatePolicy.FORCE);
         }


### PR DESCRIPTION
Original contribution by @DavidTavoularis in #729:

a. Better HTTPS with Client authentication :

    In order to avoid too many PIN/Password requests (HTTPS hanshakes), downloads first the initial jar (mono-thread) then all remaining ones (multi-thread)
    In case of initial jar download failure (Client Certificate Selection cancel, incorrect PIN/Password, ...), fail fast and do not try to download remaining jars
    No resource prefetch, otherwise deployment.cache.parallelDownloadCount is not enforced

b. New Security Dialog UI for Client Certificate Selection :

    Ability to display details on each certificate
    Shown in TaskBar
    Cancellable
    Selection using double-click, Enter key or OK button
    Internationalization

c. SmartCard support on Windows

    Introduction of a Merged Key Manager for user, system and browser key stores
    Client alias selection using a preference algorithm :
    a) Get all non-expired aliases with extension ClientCert (1.3.6.1.5.5.7.3.2) or ANY (2.5.29.37.0)
    if only one, it is selected, if more than one, a UI helps to select one of them.
    b) Otherwise, get all expired aliases with extension ClientCert (1.3.6.1.5.5.7.3.2) or ANY (2.5.29.37.0)
    if only one, it is selected, if more than one, a UI helps to select one of them.
    c) Otherwise, get all remaining aliases
    if only one, it is selected, if more than one, a UI helps to select one of them.
    UI will display the suffix " (from user keystore)" or " (from system keystore)" or " (from browser keystore)"
    If user cancels the Client Certificate UI, it is remembered for next chooseClientAlias call
    Client alias selection is cached per remote host
