### PR TITLE
Support signed JARs with ECDSA signatures.

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
+++ b/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
@@ -562,6 +562,7 @@ public class JarCertVerifier implements CertVerifier {
                 name.endsWith(".SF") ||
                 name.endsWith(".DSA") ||
                 name.endsWith(".RSA") ||
+                name.endsWith(".EC") ||
                 SIG.matcher(name).matches()
         );
     }


### PR DESCRIPTION
The signature block for ECDSA signatures has the extension ".EC",
add that as possible METAINF entry.

Otherwise the JAR is considered as unsigned, when ECDSA signatures are used.

Signed-off-by: Frank Behrens <frank@harz.behrens.de>