### PR TITLE
Enable Windows Key Store Access

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/CertWarningPane.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/CertWarningPane.java
@@ -332,7 +332,7 @@ public class CertWarningPane extends SecurityDialogPanel {
 
     public void saveCert() {
         try {
-            KeyStore ks = KeyStores.getKeyStore(Level.USER, Type.CERTS).getKs();
+            KeyStore ks = KeyStores.getWrapContainer(Level.USER, Type.CERTS).getWrap().getKs();
             X509Certificate c = (X509Certificate) parent.getCertVerifier().getPublisher(null);
             CertificateUtils.addToKeyStore(c, ks);
             File keyStoreFile = KeyStores.getKeyStoreLocation(Level.USER, Type.CERTS).getFile();

--- a/core/src/main/java/net/sourceforge/jnlp/config/ConfigurationConstants.java
+++ b/core/src/main/java/net/sourceforge/jnlp/config/ConfigurationConstants.java
@@ -110,6 +110,15 @@ public interface ConfigurationConstants {
     String KEY_SECURITY_EXPIRED_WARNING = "deployment.security.expired.warning";
 
     String KEY_SECURITY_JSSE_HOSTMISMATCH_WARNING = "deployment.security.jsse.hostmismatch.warning";
+    
+    
+    /**
+     * Properties to manage to access Windows key stores
+     */
+    String KEY_SECURITY_USE_ROOTCA_STORE_TYPE_WINDOWS_ROOT = "deployment.security.use.rootca.store.type.windowsRoot";
+    
+    String KEY_SECURITY_USE_ROOTCA_STORE_TYPE_WINDOWS_MY = "deployment.security.use.rootca.store.type.windowsMy";        
+    
 
     /**
      * Boolean. Only show security prompts to user if true

--- a/core/src/main/java/net/sourceforge/jnlp/config/Defaults.java
+++ b/core/src/main/java/net/sourceforge/jnlp/config/Defaults.java
@@ -183,6 +183,21 @@ public class Defaults {
             ),
 
             /*
+             * Windows certificates key stores
+             */
+            Setting.createDefault(
+                    ConfigurationConstants.KEY_SECURITY_USE_ROOTCA_STORE_TYPE_WINDOWS_ROOT,
+                    String.valueOf(false),
+                    ValidatorFactory.createBooleanValidator()
+            ),
+            Setting.createDefault(
+                    ConfigurationConstants.KEY_SECURITY_USE_ROOTCA_STORE_TYPE_WINDOWS_MY,
+                    String.valueOf(false),
+                    ValidatorFactory.createBooleanValidator()
+            ),               
+            
+            
+            /*
              * security access and control
              */
             Setting.createDefault(

--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
@@ -272,7 +272,7 @@ public class JNLPRuntime {
         try {
             SSLSocketFactory sslSocketFactory;
             SSLContext context = SSLContext.getInstance("SSL");
-            KeyStore ks = KeyStores.getKeyStore(KeyStores.Level.USER, KeyStores.Type.CLIENT_CERTS).getKs();
+            KeyStore ks = KeyStores.getWrapContainer(KeyStores.Level.USER, KeyStores.Type.CLIENT_CERTS).getWrap().getKs();
             KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
             SecurityUtil.initKeyManagerFactory(kmf, ks);
             TrustManager[] trust = new TrustManager[] { getSSLSocketTrustManager() };

--- a/core/src/main/java/net/sourceforge/jnlp/security/CertificateUtils.java
+++ b/core/src/main/java/net/sourceforge/jnlp/security/CertificateUtils.java
@@ -126,7 +126,7 @@ public class CertificateUtils {
         BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file));
         KeyStore keyStore = KeyStore.getInstance("PKCS12");
         keyStore.load(bis, password);
-        KeyStore systemCa = KeyStores.getKeyStore(KeyStores.Level.SYSTEM, KeyStores.Type.CA_CERTS).getKs();
+        KeyStore systemCa = KeyStores.getWrapContainer(KeyStores.Level.SYSTEM, KeyStores.Type.CA_CERTS).getWrap().getKs();
 
         Enumeration<String> aliasList = keyStore.aliases();
 
@@ -182,7 +182,7 @@ public class CertificateUtils {
                     // Verify against this entry
                     final String alias = aliases.nextElement();
                     if (c.equals(keyStore.getCertificate(alias))) {
-                        LOG.debug("{} found in cacerts ({})", c.getSubjectX500Principal().getName(), KeyStores.getPathToKeystore(keyStore));
+                        LOG.debug("{} found in cacerts ({})", c.getSubjectX500Principal().getName(), KeyStores.getLocationToKeystore(keyStore));
                         return true;
                     } // else continue
                 }

--- a/core/src/main/java/net/sourceforge/jnlp/security/KeyStores.java
+++ b/core/src/main/java/net/sourceforge/jnlp/security/KeyStores.java
@@ -33,13 +33,6 @@ statement from your version.
 */
 package net.sourceforge.jnlp.security;
 
-import net.adoptopenjdk.icedteaweb.i18n.Translator;
-import net.adoptopenjdk.icedteaweb.logging.Logger;
-import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
-import net.sourceforge.jnlp.config.InfrastructureFileDescriptor;
-import net.sourceforge.jnlp.config.PathsAndFiles;
-import net.sourceforge.jnlp.util.RestrictedFileUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.security.AllPermission;
@@ -53,6 +46,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import net.adoptopenjdk.icedteaweb.i18n.Translator;
+import net.adoptopenjdk.icedteaweb.logging.Logger;
+import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
+import net.sourceforge.jnlp.config.InfrastructureFileDescriptor;
+import net.sourceforge.jnlp.config.PathsAndFiles;
+import net.sourceforge.jnlp.security.windows.WindowsKeyStoresManager;
+import net.sourceforge.jnlp.security.windows.WindowsKeyStoresManager.WindowsKeyStoreType;
+import net.sourceforge.jnlp.util.RestrictedFileUtils;
+
 /**
  * The {@code KeyStores} class allows easily accessing the various KeyStores
  * used.
@@ -61,7 +63,24 @@ public final class KeyStores {
 
     private static final Logger LOG = LoggerFactory.getLogger(KeyStores.class);
 
-    public static class KeyStoreWithPath {
+    public static class KeyStoreWrapContainer<T extends KeyStoreWrap>{
+    	private final T wrap;
+    	
+    	public KeyStoreWrapContainer(T t){
+    		this.wrap = t;
+    	}
+
+		public T getWrap() {
+			return wrap;
+		}
+    }
+    
+    public static interface KeyStoreWrap{
+    	public KeyStore getKs();
+    	public Family getFamily();
+    }
+    
+    public static class KeyStoreWithPath implements KeyStoreWrap {
 
         private final KeyStore ks;
         private final String path;
@@ -78,6 +97,40 @@ public final class KeyStores {
         public String getPath() {
             return path;
         }
+
+		@Override
+		public Family getFamily() {
+			return Family.JKS;
+		}
+    }
+    
+    public static class KeyStoreWindows implements KeyStoreWrap {
+
+        private final KeyStore ks;
+        private final WindowsKeyStoreType storeType;
+
+        public KeyStoreWindows(KeyStore ks, WindowsKeyStoreType storeType) {
+            this.ks = ks;
+            this.storeType = storeType;
+        }
+
+        public KeyStore getKs() {
+            return ks;
+        }
+
+        public WindowsKeyStoreType getStoreType() {
+            return storeType;
+        }
+
+		@Override
+		public Family getFamily() {
+			return Family.WINDOWS;
+		}
+    }  
+    
+    public enum Family {
+    	JKS,
+    	WINDOWS
     }
 
     /* this gets turned into user-readable strings, see toUserReadableString */
@@ -94,39 +147,62 @@ public final class KeyStores {
         CLIENT_CERTS,
     }
 
-    public static final Map<Integer, String> keystoresPaths = new HashMap<>();
+    public static final Map<Integer, String> keystoresLocations = new HashMap<>();
 
     private static final String KEYSTORE_TYPE = "JKS";
 
     /**
-     * Returns a KeyStore corresponding to the appropriate level level (user or
+     * Returns a KeyStoreWrapContainer corresponding to the appropriate level level (user or
      * system) and type.
      *
      * @param level whether the KeyStore desired is a user-level or system-level KeyStore
      * @param type  the type of KeyStore desired
      * @return a KeyStore containing certificates from the appropriate
      */
-    public static KeyStoreWithPath getKeyStore(Level level, Type type) {
+    public static KeyStoreWrapContainer<KeyStoreWrap> getWrapContainer(Level level, Type type) {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(new AllPermission());
         }
 
-        final String location = getKeyStoreLocation(level, type).getFullPath();
+    	//The existence and accessibility of a Windows Key Store is checked if required by configuration
+        //Windows-ROOT	--> "deployment.security.use.rootca.store.type.windowsRoot=true"
+        //Windows-My 	--> "deployment.security.use.rootca.store.type.windowsMy=true"
+        
+        final WindowsKeyStoresManager windowsStore = WindowsKeyStoresManager.getInfo(type);
+        final String location;
+        
+        KeyStoreWrapContainer<KeyStoreWrap> keyStoreWrapContainer = null;
+        
+        if(windowsStore.isAccessible())
+        	location = windowsStore.getType().getStoreType();
+        else
+        	location = getKeyStoreLocation(level, type).getFullPath();
+
         KeyStore ks = null;
         try {
-            ks = createKeyStoreFromFile(new File(location), level == Level.USER);
+        	if(windowsStore.isAccessible()) {
+        		ks = createKeyStoreFromWindows(location);
+                keyStoreWrapContainer = new KeyStoreWrapContainer<KeyStoreWrap>(new KeyStoreWindows(ks, windowsStore.getType()));
+        		
+        	}
+        	else {
+        		ks = createKeyStoreFromFile(new File(location), level == Level.USER);
+                keyStoreWrapContainer = new KeyStoreWrapContainer<KeyStoreWrap>(new KeyStoreWithPath(ks, location));
+        		
+        	}
             //hashcode is used instead of instance so when no references are left
             //to keystore, then this will not be blocker for garbage collection
-            keystoresPaths.put(ks.hashCode(), location);
+        	keystoresLocations.put(ks.hashCode(), location);
         } catch (Exception e) {
             LOG.error("failed to get keystore " + level + " " + type + " -> " + location, e);
         }
-        return new KeyStoreWithPath(ks, location);
+        
+        return keyStoreWrapContainer;
     }
 
-    public static String getPathToKeystore(KeyStore k) {
-        final String s = keystoresPaths.get(k.hashCode());
+    public static String getLocationToKeystore(KeyStore k) {
+        final String s = keystoresLocations.get(k.hashCode());
         if (s == null) {
             return "unknown keystore location";
         }
@@ -141,24 +217,26 @@ public final class KeyStores {
      */
     public static List<KeyStore> getCertKeyStores() {
         final List<KeyStore> result = new ArrayList<>(10);
-        /* System-level JSSE certificates */
+
         KeyStore ks;
-        ks = getKeyStore(Level.SYSTEM, Type.JSSE_CERTS).getKs();
+        
+        /* System-level JSSE certificates */              
+        ks = getWrapContainer(Level.SYSTEM, Type.JSSE_CERTS).getWrap().getKs();        
         if (ks != null) {
             result.add(ks);
         }
         /* System-level certificates */
-        ks = getKeyStore(Level.SYSTEM, Type.CERTS).getKs();
+        ks = getWrapContainer(Level.SYSTEM, Type.CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
         /* User-level JSSE certificates */
-        ks = getKeyStore(Level.USER, Type.JSSE_CERTS).getKs();
+        ks = getWrapContainer(Level.USER, Type.JSSE_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
         /* User-level certificates */
-        ks = getKeyStore(Level.USER, Type.CERTS).getKs();
+        ks = getWrapContainer(Level.USER, Type.CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
@@ -173,24 +251,25 @@ public final class KeyStores {
      */
     public static List<KeyStore> getCAKeyStores() {
         List<KeyStore> result = new ArrayList<>(10);
-        /* System-level JSSE CA certificates */
+        
         KeyStore ks;
-        ks = getKeyStore(Level.SYSTEM, Type.JSSE_CA_CERTS).getKs();
+        /* System-level JSSE CA certificates */
+        ks = getWrapContainer(Level.SYSTEM, Type.JSSE_CA_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
         /* System-level CA certificates */
-        ks = getKeyStore(Level.SYSTEM, Type.CA_CERTS).getKs();
+        ks = getWrapContainer(Level.SYSTEM, Type.CA_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
         /* User-level JSSE CA certificates */
-        ks = getKeyStore(Level.USER, Type.JSSE_CA_CERTS).getKs();
+        ks = getWrapContainer(Level.USER, Type.JSSE_CA_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
         /* User-level CA certificates */
-        ks = getKeyStore(Level.USER, Type.CA_CERTS).getKs();
+        ks = getWrapContainer(Level.USER, Type.CA_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
@@ -208,12 +287,12 @@ public final class KeyStores {
         List<KeyStore> result = new ArrayList<>();
 
         KeyStore ks;
-        ks = getKeyStore(Level.SYSTEM, Type.CLIENT_CERTS).getKs();
+        ks = getWrapContainer(Level.SYSTEM, Type.CLIENT_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
 
-        ks = getKeyStore(Level.USER, Type.CLIENT_CERTS).getKs();
+        ks = getWrapContainer(Level.USER, Type.CLIENT_CERTS).getWrap().getKs();
         if (ks != null) {
             result.add(ks);
         }
@@ -342,4 +421,18 @@ public final class KeyStores {
         }
         return ks;
     }
+    
+
+    private static KeyStore createKeyStoreFromWindows(String windowsStoreType) throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+        final KeyStore ks = KeyStore.getInstance(windowsStoreType);
+        if (ks!=null) {
+            LOG.debug("Keystore windows {} exists.", windowsStoreType);
+            SecurityUtil.loadKeyStore(ks, null);
+        } else {
+            LOG.debug("Keystore windows {} does not exists.", windowsStoreType);
+            SecurityUtil.loadKeyStore(ks, null);
+        }
+        return ks;
+    }	    
+        
 }

--- a/core/src/main/java/net/sourceforge/jnlp/security/SecurityUtil.java
+++ b/core/src/main/java/net/sourceforge/jnlp/security/SecurityUtil.java
@@ -34,14 +34,10 @@ statement from your version.
 
 package net.sourceforge.jnlp.security;
 
-import net.adoptopenjdk.icedteaweb.IcedTeaWebConstants;
-import net.adoptopenjdk.icedteaweb.JavaSystemProperties;
-import net.adoptopenjdk.icedteaweb.logging.Logger;
-import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
-import net.sourceforge.jnlp.security.KeyStores.Level;
-import net.sourceforge.jnlp.security.KeyStores.Type;
+import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.SSL_TRUST_STORE;
+import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.SSL_TRUST_STORE_PASSWORD;
+import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.SSL_TRUST_STORE_TYPE;
 
-import javax.net.ssl.KeyManagerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -54,9 +50,15 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 
-import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.SSL_TRUST_STORE;
-import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.SSL_TRUST_STORE_PASSWORD;
-import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.SSL_TRUST_STORE_TYPE;
+import javax.net.ssl.KeyManagerFactory;
+
+import net.adoptopenjdk.icedteaweb.IcedTeaWebConstants;
+import net.adoptopenjdk.icedteaweb.JavaSystemProperties;
+import net.adoptopenjdk.icedteaweb.logging.Logger;
+import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
+import net.sourceforge.jnlp.security.KeyStores.Level;
+import net.sourceforge.jnlp.security.KeyStores.Type;
+import net.sourceforge.jnlp.security.windows.WindowsKeyStoresManager;
 
 public class SecurityUtil {
 
@@ -353,8 +355,14 @@ public class SecurityUtil {
     }
 
     public static void loadKeyStore(KeyStore ks, File f) throws IOException, NoSuchAlgorithmException, CertificateException {
-        try {
-            LOG.debug("Loading Keystore {}", f != null ? f.toString() : "Unknown");
+        try {       	
+        	if(WindowsKeyStoresManager.isWindowsStore(ks)) {
+        		LOG.debug("Loading Keystore {}", ks.getType());
+        	}
+        	else {        	
+        		LOG.debug("Loading Keystore {}", f != null ? f.toString() : "Unknown");
+        	}
+
             KeystorePasswordAttempter.INSTANCE.unlockKeystore(
                     new KeystorePasswordAttempter.KeystoreOperation(ks, f) {
 

--- a/core/src/main/java/net/sourceforge/jnlp/security/windows/WindowsKeyStoresManager.java
+++ b/core/src/main/java/net/sourceforge/jnlp/security/windows/WindowsKeyStoresManager.java
@@ -1,0 +1,127 @@
+package net.sourceforge.jnlp.security.windows;
+
+import java.security.KeyStore;
+import java.util.ArrayList;
+
+import net.sourceforge.jnlp.config.ConfigurationConstants;
+import net.sourceforge.jnlp.config.DeploymentConfiguration;
+import net.sourceforge.jnlp.runtime.JNLPRuntime;
+import net.sourceforge.jnlp.security.KeyStores;
+
+public class WindowsKeyStoresManager {
+	
+	private boolean accessible;
+	private WindowsKeyStoreType type;	
+	
+	private static final ArrayList<KeyStores.Type> ADMITTED_STORE_TYPES;
+	private static final String KS_PROVIDER_NAME = "SunMSCAPI";
+	
+	private static final String OS_NAME = System.getProperty("os.name") == null ? "" : System.getProperty("os.name");
+	
+	private static final WindowsKeyStoresManager INSTANCE;
+	private static final WindowsKeyStoresManager EMPTY_INSTANCE = new WindowsKeyStoresManager();
+	
+	static {
+		//Admitted Stores - Only Root CA admitted
+		ADMITTED_STORE_TYPES = new ArrayList<KeyStores.Type>();		
+		ADMITTED_STORE_TYPES.add(KeyStores.Type.CA_CERTS);
+		
+		boolean isWindowsMachine = OS_NAME.indexOf("Windows") >= 0;
+		if(isWindowsMachine) {
+			//Load configurations. Only for Windows OS machines.
+			WindowsKeyStoresManager windowsStoresManager = new WindowsKeyStoresManager();
+			
+	        DeploymentConfiguration config = JNLPRuntime.getConfiguration();
+	        
+	        boolean windowsRoot = Boolean.parseBoolean(config.getProperty(ConfigurationConstants.KEY_SECURITY_USE_ROOTCA_STORE_TYPE_WINDOWS_ROOT));
+	        boolean windowsMy = Boolean.parseBoolean(config.getProperty(ConfigurationConstants.KEY_SECURITY_USE_ROOTCA_STORE_TYPE_WINDOWS_MY));		
+			
+	        windowsStoresManager.accessible = windowsRoot || windowsMy;
+	        
+	        if(windowsRoot && windowsMy) {
+	        	windowsStoresManager.type = WindowsKeyStoreType.WINDOWS_ROOT;
+	        }
+	        else if(!windowsRoot && windowsMy) {
+	        	windowsStoresManager.type = WindowsKeyStoreType.WINDOWS_MY;
+	        }
+	        else if(windowsRoot && !windowsMy) {
+	        	windowsStoresManager.type = WindowsKeyStoreType.WINDOWS_ROOT;
+	        }
+	        else {
+	        	windowsStoresManager.type = null;
+	        }
+	        
+	        INSTANCE = windowsStoresManager;	        
+		}
+		else {
+			INSTANCE = EMPTY_INSTANCE;
+		}
+
+		
+	}
+
+	private WindowsKeyStoresManager () {
+		
+	}
+	
+	public enum WindowsKeyStoreType {
+		WINDOWS_ROOT("Windows-ROOT","Windows Trusted Root Certification Authorities"),
+		WINDOWS_MY("Windows-MY","Windows Personal");
+		
+		private String type;
+		private String description;
+
+		WindowsKeyStoreType(String storeType, String storeDescription){
+			this.type = storeType;
+			this.description = storeDescription;
+		}
+
+		public String getStoreType() {
+			return type;
+		}
+		
+		
+		public String getDescription() {
+			return description;
+		}		
+		
+		public static WindowsKeyStoreType getValue(String storeType) {
+		    for (WindowsKeyStoreType st : WindowsKeyStoreType.values()) {
+		        if (st.getStoreType().equals(storeType)) {
+		            return st;
+		        }
+		    }
+		    
+		    return null;
+		}		
+	}
+	
+	public boolean isAccessible() {
+		return accessible;
+	}
+
+	public WindowsKeyStoreType getType() {
+		return type;
+	}	
+	
+	public static WindowsKeyStoresManager getInfo(KeyStores.Type storeType) {		
+		
+		boolean admitted = ADMITTED_STORE_TYPES.contains(storeType);
+		
+		if(!admitted)
+			return EMPTY_INSTANCE;
+		else
+			return INSTANCE;
+		
+		
+	}
+	
+	public static boolean isWindowsStore(KeyStore ks) {
+		
+		if(ks!= null && ks.getProvider() != null)
+			return KS_PROVIDER_NAME.equals(ks.getProvider().getName());
+		else
+			return false;
+		
+	}	
+}

--- a/core/src/test/java/net/sourceforge/jnlp/security/KeyStoresTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/security/KeyStoresTest.java
@@ -33,13 +33,15 @@ statement from your version.
 */
 package net.sourceforge.jnlp.security;
 
-import net.sourceforge.jnlp.config.InfrastructureFileDescriptor;
-import net.sourceforge.jnlp.config.PathsAndFiles;
+import java.security.Permission;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.security.Permission;
+import net.sourceforge.jnlp.config.InfrastructureFileDescriptor;
+import net.sourceforge.jnlp.config.PathsAndFiles;
+import net.sourceforge.jnlp.security.KeyStores.KeyStoreWrap;
 
 public class KeyStoresTest {
 
@@ -124,6 +126,20 @@ public class KeyStoresTest {
         s = KeyStores.getKeyStoreLocation(KeyStores.Level.SYSTEM, KeyStores.Type.JSSE_CERTS);
         Assert.assertEquals(s.getFile(), PathsAndFiles.SYS_JSSECERT.getFile());
         Assert.assertEquals(true, dm.called);
-    } 
+    }
+
+    @Test
+    public void getKeyStoreWindowsRootTestSM() {
+        DummySM dm = new DummySM();
+        System.setSecurityManager(dm);
+        
+        KeyStoreWrap keyStoreWrap;
+        
+        keyStoreWrap = KeyStores.getWrapContainer(KeyStores.Level.SYSTEM, KeyStores.Type.CA_CERTS).getWrap();        
+        Assert.assertEquals(keyStoreWrap.getFamily(), KeyStores.Family.WINDOWS);
+        
+        keyStoreWrap = KeyStores.getWrapContainer(KeyStores.Level.USER, KeyStores.Type.CA_CERTS).getWrap();        
+        Assert.assertEquals(keyStoreWrap.getFamily(), KeyStores.Family.WINDOWS);
+    }    
 
 }

--- a/core/src/test/java/net/sourceforge/jnlp/security/KeyStoresTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/security/KeyStoresTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import net.sourceforge.jnlp.config.InfrastructureFileDescriptor;
 import net.sourceforge.jnlp.config.PathsAndFiles;
 import net.sourceforge.jnlp.security.KeyStores.KeyStoreWrap;
+import net.sourceforge.jnlp.security.windows.WindowsKeyStoresManager;
 
 public class KeyStoresTest {
 
@@ -135,11 +136,16 @@ public class KeyStoresTest {
         
         KeyStoreWrap keyStoreWrap;
         
-        keyStoreWrap = KeyStores.getWrapContainer(KeyStores.Level.SYSTEM, KeyStores.Type.CA_CERTS).getWrap();        
-        Assert.assertEquals(keyStoreWrap.getFamily(), KeyStores.Family.WINDOWS);
+        final WindowsKeyStoresManager windowsStore = WindowsKeyStoresManager.getInfo(KeyStores.Type.CA_CERTS);
         
-        keyStoreWrap = KeyStores.getWrapContainer(KeyStores.Level.USER, KeyStores.Type.CA_CERTS).getWrap();        
-        Assert.assertEquals(keyStoreWrap.getFamily(), KeyStores.Family.WINDOWS);
+        if(windowsStore.isAccessible()) {
+        
+	        keyStoreWrap = KeyStores.getWrapContainer(KeyStores.Level.SYSTEM, KeyStores.Type.CA_CERTS).getWrap();        
+	        Assert.assertEquals(keyStoreWrap.getFamily(), KeyStores.Family.WINDOWS);
+	        
+	        keyStoreWrap = KeyStores.getWrapContainer(KeyStores.Level.USER, KeyStores.Type.CA_CERTS).getWrap();        
+	        Assert.assertEquals(keyStoreWrap.getFamily(), KeyStores.Family.WINDOWS);
+        }
     }    
 
 }


### PR DESCRIPTION
The changes contained in the commit allow, through appropriate configurations, to be able to access the Windows Key Stores through the use of the SunMSCAPI.
This access is allowed only if the software is installed on a Windows OS machine.

Into deployment.properties
"deployment.security.use.rootca.store.type.windowsRoot=true" --> Allow to access Windows-ROOT Key Store
"deployment.security.use.rootca.store.type.windowsMy=true" --> Allow to access Windows-My KeyStore

![itw-settings-certificates](https://user-images.githubusercontent.com/42802710/129009480-e821391b-120c-42c4-a463-0467e9f730a2.png)
