### PR TITLE
backport classloader patch from #783

### DIFF
--- a/netx/net/sourceforge/jnlp/runtime/JNLPClassLoader.java
+++ b/netx/net/sourceforge/jnlp/runtime/JNLPClassLoader.java
@@ -1559,6 +1559,12 @@ public class JNLPClassLoader extends URLClassLoader {
      */
     @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            return loadClassImpl(name);
+        }
+    }
+
+    private Class<?> loadClassImpl(String name) throws ClassNotFoundException {
         Class<?> result = findLoadedClassAll(name);
 
         // try parent classloader


### PR DESCRIPTION
See #783 fixed in master branch.

Please consider including it in 1.8 branch.

It's confirmed that the patch fixes the following exception in 1.8

> java.lang.LinkageError: loader (instance of  net/sourceforge/jnlp/runtime/JNLPClassLoader): attempted  duplicate class definition for name: "com/thoughtworks/xstream/mapper/EnumMapper"
