### PR TITLE
add nashorn based pac evaluator

### DIFF
--- a/netx/net/sourceforge/jnlp/runtime/NashornBasedPacEvaluator.java
+++ b/netx/net/sourceforge/jnlp/runtime/NashornBasedPacEvaluator.java
@@ -1,0 +1,69 @@
+package net.sourceforge.jnlp.runtime;
+
+import jdk.nashorn.api.scripting.URLReader;
+import net.sourceforge.jnlp.util.TimedHashMap;
+import net.sourceforge.jnlp.util.logging.OutputController;
+
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import java.net.URL;
+
+public class NashornBasedPacEvaluator implements PacEvaluator {
+
+    private final TimedHashMap<String, String> cache;
+
+    private static ScriptEngine engine = null;
+
+    public NashornBasedPacEvaluator(URL pacUrl) {
+        URL pacFuncsUrl = NashornBasedPacEvaluator.class.getResource("/net/sourceforge/jnlp/runtime/pac-funcs.js");
+        JNLPPolicy.enablePac(pacUrl, pacFuncsUrl);
+
+        engine = (new ScriptEngineManager()).getEngineByName("nashorn");
+        try {
+            engine.eval(new URLReader(pacFuncsUrl));
+            engine.eval(new URLReader(pacUrl));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        if (engine == null) {
+            OutputController.getLogger().log(OutputController.Level.ERROR_ALL, "Warning: No nashorn engine found");
+        } else {
+            OutputController.getLogger().log(OutputController.Level.ERROR_DEBUG, "Using the Nashorn based PAC evaluator for url " + pacUrl);
+        }
+
+        cache = new TimedHashMap<>();
+    }
+
+    public String getProxies(URL url) {
+        String cachedResult = getFromCache(url);
+        if (cachedResult != null) {
+            return cachedResult;
+        }
+
+        String result = getProxiesWithoutCaching(url);
+        addToCache(url, result);
+        return result;
+    }
+
+    private String getFromCache(URL url) {
+        String lookupString = url.getProtocol() + "://" + url.getHost();
+        return cache.get(lookupString);
+    }
+
+    private void addToCache(URL url, String proxyResult) {
+        String lookupString = url.getAuthority() + "://" + url.getHost();
+        cache.put(lookupString, proxyResult);
+    }
+
+    protected String getProxiesWithoutCaching(final URL url) {
+        try {
+            return (String)((Invocable)engine).invokeFunction("FindProxyForURL", url.toString(), url.getHost());
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        return "DIRECT";
+    }
+}

--- a/netx/net/sourceforge/jnlp/runtime/PacEvaluatorFactory.java
+++ b/netx/net/sourceforge/jnlp/runtime/PacEvaluatorFactory.java
@@ -64,7 +64,7 @@ public class PacEvaluatorFactory {
         }
 
         if (properties == null) {
-            return new FakePacEvaluator();
+            return new NashornBasedPacEvaluator(pacUrl);
         }
 
         String available = properties.getProperty("rhino.available");
@@ -92,6 +92,6 @@ public class PacEvaluatorFactory {
             }
         }
 
-        return new FakePacEvaluator();
+        return new NashornBasedPacEvaluator(pacUrl);
     }
 }


### PR DESCRIPTION
Please review the patch that introduces an alternative Nashorn-based implementation for PAC (proxy-auto-config) functionality.

Switching to Nashorn will help to fix various compatibilities issues (that worked fine with Oracle JRE). E.g. an application may bundle Rhino itself and different versions of Rhino may conflict with each other.

The proposed patch doesn't change the behaviour if --with-rhino option is explicitly passed to configure script. It should be enough not to pass --with-rhino option to activate Nashorn-based implementation.

As per [1], the implementation doesn't use "eval(String)" method as the PAC scripts will treated as untrusted. Instead, the needed set of permissions is granted to the PAC scripts via Policy.getPermissions().

[1] https://wiki.openjdk.java.net/display/Nashorn/Nashorn+script+security+permissions
