### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/UnsignedAppletsTrustingListPanel.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/controlpanel/UnsignedAppletsTrustingListPanel.java
@@ -94,6 +94,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -593,7 +594,7 @@ public class UnsignedAppletsTrustingListPanel extends JPanel {
 
         File f = null;
         try {
-            f = File.createTempFile("appletTable", "validation");
+            f = Files.createTempFile("appletTable", "validation").toFile();
         } catch (Exception ex) {
             LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, ex);
             JOptionPane.showMessageDialog(this, Translator.R("APPEXTSECguiPanelCanNOtValidate", ex.toString()));

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogsTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/SecurityDialogsTest.java
@@ -66,6 +66,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.HashSet;
 
 @Ignore
@@ -142,7 +143,7 @@ public class SecurityDialogsTest extends NoStdOutErrTest {
     @BeforeClass
     public static void backupAppletSecurity() throws IOException {
         if (PathsAndFiles.APPLET_TRUST_SETTINGS_USER.getFile().exists()) {
-            appletSecurityBackup = File.createTempFile("appletSecurity", "itwTestBackup");
+            appletSecurityBackup = Files.createTempFile("appletSecurity", "itwTestBackup").toFile();
             FirefoxProfilesOperator.copyFile(PathsAndFiles.APPLET_TRUST_SETTINGS_USER.getFile(), appletSecurityBackup);
         }
     }

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/UnsignedAppletTrustConfirmationTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/UnsignedAppletTrustConfirmationTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -107,7 +108,7 @@ public class UnsignedAppletTrustConfirmationTest {
     @BeforeClass
     public static void backupAppTrust() throws IOException{
         PathsAndFiles.APPLET_TRUST_SETTINGS_USER.getFile().createNewFile();
-        backup = File.createTempFile("appletExtendedSecurity", "itwUnittest");
+        backup = Files.createTempFile("appletExtendedSecurity", "itwUnittest").toFile();
         backup.deleteOnExit();
         FirefoxProfilesOperator.copyFile(PathsAndFiles.APPLET_TRUST_SETTINGS_USER.getFile(), backup);
     }

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/impl/LegacyUnsignedAppletActionStorageImplTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/impl/LegacyUnsignedAppletActionStorageImplTest.java
@@ -35,6 +35,7 @@ package net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextended
 import net.adoptopenjdk.icedteaweb.testing.ServerAccess;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendedsecurity.UnsignedAppletActionEntry;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.remember.AppletSecurityActions;
@@ -61,9 +62,9 @@ public class LegacyUnsignedAppletActionStorageImplTest {
 
     @BeforeClass
     public static void prepareTestFiles() throws IOException {
-        f1 = File.createTempFile("itwMatching", "testFile1");
-        f2 = File.createTempFile("itwMatching", "testFile2");
-        f3 = File.createTempFile("itwMatching", "testFile3");
+        f1 = Files.createTempFile("itwMatching", "testFile1").toFile();
+        f2 = Files.createTempFile("itwMatching", "testFile2").toFile();
+        f3 = Files.createTempFile("itwMatching", "testFile3").toFile();
         FileUtils.saveFileUtf8(versionLine+"A 123456 .* .* jar1,jar2", f1);
         FileUtils.saveFileUtf8(versionLine+"N 123456 .* \\Qbla\\E jar1,jar2", f2);
         FileUtils.saveFileUtf8(versionLine
@@ -75,10 +76,10 @@ public class LegacyUnsignedAppletActionStorageImplTest {
                 + "nn 1363281783104 \\Qhttp://www.walter-fendt.de/ph14e/inclplane.htm\\E \\Qhttp://www.walter-fendt.de/ph14_jar/\\E Ph14English.jar,SchiefeEbene.jar"
                 + "", f3);
 
-        ff1 = File.createTempFile("itwMatching", "testFile1");
-        ff2 = File.createTempFile("itwMatching", "testFile2");
-        ff3 = File.createTempFile("itwMatching", "testFile3");
-        ff4 = File.createTempFile("itwMatching", "testFile3");
+        ff1 = Files.createTempFile("itwMatching", "testFile1").toFile();
+        ff2 = Files.createTempFile("itwMatching", "testFile2").toFile();
+        ff3 = Files.createTempFile("itwMatching", "testFile3").toFile();
+        ff4 = Files.createTempFile("itwMatching", "testFile3").toFile();
         FileUtils.saveFileUtf8(versionLine+"AXn 123456 .* .* jar1,jar2", ff1);
         FileUtils.saveFileUtf8(versionLine+"XXXXXy 123456 .* \\Qbla\\E jar1,jar2", ff2);
         FileUtils.saveFileUtf8(versionLine+"XXXXXA 123456 .* \\Qbla\\E jar1,jar2", ff4);

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/impl/UnsignedAppletActionStorageImplTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/impl/UnsignedAppletActionStorageImplTest.java
@@ -35,6 +35,7 @@ package net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextended
 import net.adoptopenjdk.icedteaweb.testing.ServerAccess;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextendedsecurity.UnsignedAppletActionEntry;
 import net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.remember.ExecuteAppletAction;
@@ -80,9 +81,9 @@ public class UnsignedAppletActionStorageImplTest {
 
     @BeforeClass
     public static void prepareTestFiles() throws IOException {
-        f1 = File.createTempFile("itwMatching", "testFile1");
-        f2 = File.createTempFile("itwMatching", "testFile2");
-        f3 = File.createTempFile("itwMatching", "testFile3");
+        f1 = Files.createTempFile("itwMatching", "testFile1").toFile();
+        f2 = Files.createTempFile("itwMatching", "testFile2").toFile();
+        f3 = Files.createTempFile("itwMatching", "testFile3").toFile();
         FileUtils.saveFileUtf8(versionLine+"c1:A{YES}; 123456 .* .* jar1,jar2", f1);
         FileUtils.saveFileUtf8(versionLine+"c1:N{NO}; 123456 .* \\Qbla\\E jar1,jar2", f2);
         FileUtils.saveFileUtf8(versionLine
@@ -94,10 +95,10 @@ public class UnsignedAppletActionStorageImplTest {
                 + "c1:n{NO};c2:n{NO}; 1363281783104 \\Qhttp://www.walter-fendt.de/ph14e/inclplane.htm\\E \\Qhttp://www.walter-fendt.de/ph14_jar/\\E Ph14English.jar,SchiefeEbene.jar"
                 + "", f3);
 
-        ff1 = File.createTempFile("itwMatching", "testFile1");
-        ff2 = File.createTempFile("itwMatching", "testFile2");
-        ff3 = File.createTempFile("itwMatching", "testFile3");
-        ff4 = File.createTempFile("itwMatching", "testFile3");
+        ff1 = Files.createTempFile("itwMatching", "testFile1").toFile();
+        ff2 = Files.createTempFile("itwMatching", "testFile2").toFile();
+        ff3 = Files.createTempFile("itwMatching", "testFile3").toFile();
+        ff4 = Files.createTempFile("itwMatching", "testFile3").toFile();
         FileUtils.saveFileUtf8(versionLine+"c1:A{YES};c3:n{NO}; 123456 .* .* jar1,jar2", ff1);
         FileUtils.saveFileUtf8(versionLine+"c6:y{YES}; 123456 .* \\Qbla\\E jar1,jar2", ff2);
         FileUtils.saveFileUtf8(versionLine+"c6:A{YES}; 123456 .* \\Qbla\\E jar1,jar2", ff4);

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/impl/VersionRestrictionTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/appletextendedsecurity/impl/VersionRestrictionTest.java
@@ -35,6 +35,7 @@ package net.adoptopenjdk.icedteaweb.client.parts.dialogs.security.appletextended
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -65,7 +66,7 @@ public class VersionRestrictionTest extends NoStdOutErrTest {
 
     @Before
     public void prepareNewTestFile() throws IOException {
-        testFile = File.createTempFile("itwAES", "testFile");
+        testFile = Files.createTempFile("itwAES", "testFile").toFile();
         testFile.deleteOnExit();
     }
 

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/apptrustwarningpanel/AppTrustWarningPanelTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/parts/dialogs/security/apptrustwarningpanel/AppTrustWarningPanelTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import javax.swing.JButton;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,7 +33,7 @@ public class AppTrustWarningPanelTest {
 
 
     public static void backupAppletSecurity() throws IOException {
-        appletSecurityBackup = File.createTempFile("appletSecurity", "itwTestBackup");
+        appletSecurityBackup = Files.createTempFile("appletSecurity", "itwTestBackup").toFile();
         FirefoxProfilesOperator.copyFile(PathsAndFiles.APPLET_TRUST_SETTINGS_USER.getFile(), appletSecurityBackup);
     }
 

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/client/policyeditor/PolicyEditorParsingTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/client/policyeditor/PolicyEditorParsingTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import sun.security.provider.PolicyParser;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -112,7 +113,7 @@ public class PolicyEditorParsingTest {
 
     @Before
     public void createTempFile() throws Exception {
-        file = File.createTempFile("PolicyEditor", ".policy");
+        file = Files.createTempFile("PolicyEditor", ".policy").toFile();
         file.deleteOnExit();
     }
 

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/lockingfile/LockingReaderWriterTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/lockingfile/LockingReaderWriterTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class LockingReaderWriterTest {
 
     @Before
     public void setUp() throws IOException {
-        storagefile = File.createTempFile("foo", "bar");
+        storagefile = Files.createTempFile("foo", "bar").toFile();
     }
 
     @Test

--- a/core/src/test/java/net/adoptopenjdk/icedteaweb/lockingfile/WindowsLockableFileTest.java
+++ b/core/src/test/java/net/adoptopenjdk/icedteaweb/lockingfile/WindowsLockableFileTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants.OS_NAME;
 
@@ -31,7 +32,7 @@ public class WindowsLockableFileTest {
 
     @Test
     public void testLockUnlockOkExists() throws IOException {
-        File f = File.createTempFile("itw", "lockingFile");
+        File f = Files.createTempFile("itw", "lockingFile").toFile();
         f.deleteOnExit();
         LockableFile lf = LockableFile.getInstance(f);
         lf.lock();
@@ -40,7 +41,7 @@ public class WindowsLockableFileTest {
 
     @Test
     public void testLockUnlockOkNotExists() throws IOException {
-        File f = File.createTempFile("itw", "lockingFile");
+        File f = Files.createTempFile("itw", "lockingFile").toFile();
         f.delete();
         LockableFile lf = LockableFile.getInstance(f);
         lf.lock();
@@ -49,7 +50,7 @@ public class WindowsLockableFileTest {
 
     @Test
     public void testLockUnlockNoOkNotExists() throws IOException {
-        File parent = File.createTempFile("itw", "lockingFile");
+        File parent = Files.createTempFile("itw", "lockingFile").toFile();
         parent.deleteOnExit();
         File f = new File(parent, "itwLcokingRelict");
         f.delete();

--- a/core/src/test/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoaderTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoaderTest.java
@@ -265,7 +265,7 @@ public class JNLPClassLoaderTest extends NoStdOutErrTest {
     public void tryNullManifest() throws Exception {
         File tempDirectory = temporaryFolder.newFolder();
         File jarLocation = new File(tempDirectory, "test-npe.jar");
-        File dummyContent = File.createTempFile("dummy", "context", tempDirectory);
+        File dummyContent = Files.createTempFile(tempDirectory.toPath(), "dummy", "context").toFile();
 
         /* Test with-out any attribute specified specified */
         FileTestUtils.createJarWithoutManifestContents(jarLocation, dummyContent);
@@ -289,7 +289,7 @@ public class JNLPClassLoaderTest extends NoStdOutErrTest {
         //for this test is enough to not crash jvm
         final boolean verifyBackup = JNLPRuntime.isVerifying();
         final File dir = temporaryFolder.newFolder();
-        final File dirHolder = File.createTempFile("pf-", ".jar", dir);
+        final File dirHolder = Files.createTempFile(dir.toPath(), "pf-", ".jar").toFile();
         final File jarLocation = new File(dirHolder.getParentFile(), "pf.jar");
         try {
             //it is invalid jar, so we have to disable checks first

--- a/core/src/test/java/net/sourceforge/jnlp/tools/DeploymentPropertiesModifierTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/tools/DeploymentPropertiesModifierTest.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.AbstractMap;
 
 import static org.junit.Assert.assertEquals;
@@ -55,7 +56,7 @@ public class DeploymentPropertiesModifierTest {
 
     @Test
     public void testSetProperties() throws IOException {
-        File tempUserFile = File.createTempFile("userDeploy", "");
+        File tempUserFile = Files.createTempFile("userDeploy", "").toFile();
         tempUserFile.deleteOnExit();
 
         deploymentFile = tempUserFile;
@@ -75,7 +76,7 @@ public class DeploymentPropertiesModifierTest {
 
     @Test
     public void testRestoreProperties() throws IOException {
-        File tempUserFile = File.createTempFile("userDeploy", "");
+        File tempUserFile = Files.createTempFile("userDeploy", "").toFile();
         tempUserFile.deleteOnExit();
 
         deploymentFile = tempUserFile;
@@ -99,7 +100,7 @@ public class DeploymentPropertiesModifierTest {
 
     @Test(expected = IllegalStateException.class)
     public void testRestorePropertiesRequiresPropertiesSetFirst() throws IOException {
-        File tempUserFile = File.createTempFile("userDeploy", "");
+        File tempUserFile = Files.createTempFile("userDeploy", "").toFile();
         tempUserFile.deleteOnExit();
 
         deploymentFile = tempUserFile;
@@ -115,7 +116,7 @@ public class DeploymentPropertiesModifierTest {
 
     @Test (expected = IllegalStateException.class)
     public void testUsingSameDeploymentPropertiesModifierThrowsException() throws IOException {
-        File tempUserFile = File.createTempFile("userDeploy", "");
+        File tempUserFile = Files.createTempFile("userDeploy", "").toFile();
         tempUserFile.deleteOnExit();
 
         deploymentFile = tempUserFile;
@@ -135,7 +136,7 @@ public class DeploymentPropertiesModifierTest {
 
     @Test
     public void testUsingDifferentDeploymentPropertiesModifier() throws IOException {
-        File tempUserFile = File.createTempFile("userDeploy", "");
+        File tempUserFile = Files.createTempFile("userDeploy", "").toFile();
         tempUserFile.deleteOnExit();
 
         deploymentFile = tempUserFile;
@@ -157,7 +158,7 @@ public class DeploymentPropertiesModifierTest {
     
      @Test
     public void testMultipleDeploymentPropertiesModifier() throws IOException {
-        File tempUserFile = File.createTempFile("userDeploy", "");
+        File tempUserFile = Files.createTempFile("userDeploy", "").toFile();
         tempUserFile.deleteOnExit();
 
         String content = "a.b=12\nc.d=34\ne.f=56\ng.h=78\ni.j=90";

--- a/core/src/test/java/net/sourceforge/jnlp/util/MD5SumWatcherTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/util/MD5SumWatcherTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertFalse;
@@ -52,7 +53,7 @@ public class MD5SumWatcherTest {
 
     @Before
     public void createNewFile() throws Exception {
-        file = File.createTempFile("md5sumwatchertest", "tmp");
+        file = Files.createTempFile("md5sumwatchertest", "tmp").toFile();
         file.deleteOnExit();
         watcher = new MD5SumWatcher(file);
     }

--- a/core/src/test/java/net/sourceforge/jnlp/util/logging/FileLogTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/util/logging/FileLogTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class FileLogTest {
 
@@ -57,7 +58,7 @@ public class FileLogTest {
     @BeforeClass
     public static void prepareTmpFiles() throws IOException {
         for (int i = 0; i < loggingTargets.length; i++) {
-            loggingTargets[i] = File.createTempFile("fileLogger", "iteTest");
+            loggingTargets[i] = Files.createTempFile("fileLogger", "iteTest").toFile();
             loggingTargets[i].deleteOnExit();
         }
         //delete first half of the files, logger should handle both cases

--- a/core/src/test/java/net/sourceforge/jnlp/util/logging/OutputControllerTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/util/logging/OutputControllerTest.java
@@ -48,6 +48,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Random;
 
 public class OutputControllerTest {
@@ -181,7 +182,7 @@ public class OutputControllerTest {
                     ByteArrayOutputStream os2 = new ByteArrayOutputStream();
                     OutputController oc = new OutputController(os1, os2);
 
-                    File f = File.createTempFile("replacedFilelogger", "itwTest");
+                    File f = Files.createTempFile("replacedFilelogger", "itwTest").toFile();
                     f.deleteOnExit();
                     oc.setFileLog(new WriterBasedFileLog(f.getAbsolutePath(), false));
                     LogConfig.getLogConfig().setLogToFile(true);
@@ -295,8 +296,8 @@ public class OutputControllerTest {
         ByteArrayOutputStream os1 = new ByteArrayOutputStream();
         ByteArrayOutputStream os2 = new ByteArrayOutputStream();
         OutputController oc = new OutputController(os1, os2);
-        File f1 = File.createTempFile("replacedFilelogger", "itwTest");
-        File f2 = File.createTempFile("replacedFilelogger", "itwTest");
+        File f1 = Files.createTempFile("replacedFilelogger", "itwTest").toFile();
+        File f2 = Files.createTempFile("replacedFilelogger", "itwTest").toFile();
         f1.deleteOnExit();
         f2.deleteOnExit();
         oc.setFileLog(new WriterBasedFileLog(f1.getAbsolutePath(), false));

--- a/core/src/test/java/net/sourceforge/jnlp/util/logging/WriterBasedFileLogTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/util/logging/WriterBasedFileLogTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class WriterBasedFileLogTest {
 
@@ -57,7 +58,7 @@ public class WriterBasedFileLogTest {
     @BeforeClass
     public static void prepareTmpFiles() throws IOException {
         for (int i = 0; i < loggingTargets.length; i++) {
-            loggingTargets[i] = File.createTempFile("WriterBasedFileLogger", "iteTest");
+            loggingTargets[i] = Files.createTempFile("WriterBasedFileLogger", "iteTest").toFile();
             loggingTargets[i].deleteOnExit();
         }
         //delete first half of the files, logger should handle both cases


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
