### PR TITLE
backport of #868

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -195,6 +195,9 @@ else
   NETX_EXCLUDE_SRCS=net.sourceforge.jnlp.MalformedXMLParser.java net.sourceforge.jnlp.util.WindowsDesktopEntry.java
 endif
 endif
+if !ENABLE_PLUGINJAR
+  NETX_EXCLUDE_SRCS+= net.sourceforge.jnlp.NetxPanel sun.applet.AppletViewerPanelAccess.java
+endif
 
 # Flags
 # macOS requires this flag, see https://youtrack.jetbrains.com/issue/IDEA-72010
@@ -246,6 +249,7 @@ export ICEDTEAPLUGIN_TARGET = stamps/liveconnect-dist.stamp
 export PLUGIN_DIR=$(TOP_BUILD_DIR)/plugin/icedteanp
 export PLUGIN_SRCDIR=$(TOP_SRC_DIR)/plugin/icedteanp
 export JSOBJECT_DIRS = netscape
+export SUN_DIR = sun
 export SUN_APPLET_DIRS = sun/applet
 export PLUGIN_PKGS = sun.applet netscape.security netscape.javascript
 export LIVECONNECT_SRCS = $(PLUGIN_SRCDIR)/java
@@ -283,7 +287,7 @@ if ENABLE_DOCS
 JAVADOC_OPTS=-use -keywords -encoding UTF-8 -splitIndex \
  -bottom '<font size="-1"> <a href="http://icedtea.classpath.org/bugzilla">Submit a bug or feature</a></font>'
 if HAVE_JAVA9
-JAVADOC_OPTS+=-source $(IT_LANGUAGE_SOURCE_VERSION)
+JAVADOC_OPTS+=-source $(IT_LANGUAGE_SOURCE_VERSION) --ignore-source-errors
 endif
 if JAVADOC_SUPPORTS_J_OPTIONS
 JAVADOC_MEM_OPTS=-J-Xmx1024m -J-Xms128m
@@ -956,11 +960,11 @@ stamps/netx-dist.stamp: stamps/netx.stamp $(TOP_BUILD_DIR)/netx.manifest stamps/
 	(cd $(NETX_DIR) ; \
 	 mkdir -p lib ; \
 	 $(SYSTEM_JDK_DIR)/bin/jar cfm lib/classes.jar \
-	  $(TOP_BUILD_DIR)/netx.manifest javax/jnlp net sun; \
+	  $(TOP_BUILD_DIR)/netx.manifest javax/jnlp net $(SUN_DIR); \
 	 cp -pPR $(SRC_DIR_LINK) $(NETX_SRCDIR) src; \
 	 find src -type f -exec chmod 640 '{}' ';' -o -type d -exec chmod 750 '{}' ';'; \
 	 cd src ; \
-	 $(ZIP) -qr $(NETX_DIR)/lib/src.zip javax net sun)
+	 $(ZIP) -qr $(NETX_DIR)/lib/src.zip javax net $(SUN_DIR))
 	mkdir -p stamps
 	touch $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -143,7 +143,6 @@ dnl PR46074 (gcc) - Missing java.net cookie code required by IcedTea plugin
 dnl IT563 - NetX uses sun.security code
 dnl IT605 - NetX depends on sun.misc HexDumpEncoder or sun.security.util.HexDumpEncoder
 dnl IT570 - NetX depends on sun.applet.AppletViewPanel
-dnl IT571 - NetX depends on com.sun.net.ssl.internal.ssl.X509ExtendedTrustManager.java
 dnl IT573 - Plugin depends on sun.awt,X11.XEmbeddedFrame.java
 dnl IT575 - Plugin depends on com.sun/jndi.toolkit.url.UrlUtil
 dnl IT576 - Plugin depends on sun.applet.AppletImageRef
@@ -172,7 +171,6 @@ else
   IT_CHECK_FOR_CLASS(SUN_MISC_LAUNCHER, [sun.misc.Launcher], [some.pkg], [$JAVA_BASE])
 fi
 IT_CHECK_FOR_CLASS(SUN_SECURITY_VALIDATOR_VALIDATOREXCEPTION, [sun.security.validator.ValidatorException], [some.pkg], [$JAVA_BASE])
-IT_CHECK_FOR_CLASS(COM_SUN_NET_SSL_INTERNAL_SSL_X509EXTENDEDTRUSTMANAGER, [com.sun.net.ssl.internal.ssl.X509ExtendedTrustManager], [some.pkg], [$JAVA_BASE])
 IT_CHECK_FOR_CLASS(SUN_NET_WWW_PROTOCOL_JAR_URLJARFILE, [sun.net.www.protocol.jar.URLJarFile], [some.pkg], [$JAVA_BASE])
 IT_CHECK_FOR_CLASS(SUN_NET_WWW_PROTOCOL_JAR_URLJARFILECALLBACK, [sun.net.www.protocol.jar.URLJarFileCallBack], [some.pkg], [$JAVA_BASE])
 if test "x$build_linux" = xyes ; then
@@ -186,9 +184,10 @@ if test "x$build_windows" = xyes ; then
 fi
 IT_CHECK_FOR_CLASS(COM_SUN_JNDI_TOOLKIT_URL_URLUTIL, [com.sun.jndi.toolkit.url.UrlUtil], [some.pkg], [$JAVA_NAMING])
 IT_CHECK_FOR_CLASS(SUN_NET_WWW_PROTOCOL_HTTP_HANDLER, [sun.net.www.protocol.http.Handler], [some.pkg], [$JAVA_BASE])
-IT_CHECK_FOR_CLASS(SUN_APPLET_APPLETIMAGEREF, [sun.applet.AppletImageRef], [sun.applet], [$JAVA_DESKTOP])
-
-IT_CHECK_FOR_SUN_APPLET_ACCESSIBILITY
+if test "$enable_pluginjar" = yes ; then
+  IT_CHECK_FOR_CLASS(SUN_APPLET_APPLETIMAGEREF, [sun.applet.AppletImageRef], [sun.applet], [$JAVA_DESKTOP])
+  IT_CHECK_FOR_SUN_APPLET_ACCESSIBILITY
+fi
 IT_CHECK_GLIB_VERSION
 IT_CHECK_XULRUNNER_MIMEDESCRIPTION_CONSTCHAR
 IT_CHECK_XULRUNNER_REQUIRES_C11

--- a/netx/net/sourceforge/jnlp/runtime/JNLPSecurityManager.java
+++ b/netx/net/sourceforge/jnlp/runtime/JNLPSecurityManager.java
@@ -18,6 +18,7 @@ package net.sourceforge.jnlp.runtime;
 
 import static net.sourceforge.jnlp.runtime.Translator.R;
 
+import java.awt.AWTPermission;
 import java.awt.Window;
 import java.net.SocketPermission;
 import java.security.AccessControlException;
@@ -343,7 +344,6 @@ class JNLPSecurityManager extends SecurityManager {
      * warning banner, and adds the window to the list of windows to
      * be disposed when the calling application exits.
      */
-    @Override
     public boolean checkTopLevelWindow(Object window) {
         ApplicationInstance app = getApplication();
 
@@ -362,7 +362,12 @@ class JNLPSecurityManager extends SecurityManager {
         // todo: set awt.appletWarning to custom message
         // todo: logo on with glass pane on JFrame/JWindow?
 
-        return super.checkTopLevelWindow(window);
+        try {
+            checkPermission(new AWTPermission("showWindowWithoutWarningBanner"));
+            return true;
+        } catch (Exception se) {
+            return false;
+        }
     }
 
     /**
@@ -432,7 +437,6 @@ class JNLPSecurityManager extends SecurityManager {
      * @exception  SecurityException  if the caller does not have
      *             permission to accesss the AWT event queue.
      */
-    @Override
     public void checkAwtEventQueueAccess() {
         /*
          * this is the templace of the code that should allow applets access to
@@ -446,7 +450,7 @@ class JNLPSecurityManager extends SecurityManager {
         // If we're about to allow access to the main EventQueue,
         // and anything untrusted is on the class context stack,
         // disallow access.
-        super.checkAwtEventQueueAccess();
+        checkPermission(new AWTPermission("accessEventQueue"));
         // }
     }
 

--- a/netx/net/sourceforge/jnlp/security/package-info.java
+++ b/netx/net/sourceforge/jnlp/security/package-info.java
@@ -32,7 +32,7 @@ obligated to do so. If you do not wish to do so, delete this exception
 statement from your version.*/
 /**
  *package generally about showing various security prompts
- *<h3>Following diagram shows how dialog is handled when some application/appelt needs to show it</h3>
+ *<h2>Following diagram shows how dialog is handled when some application/appelt needs to show it</h2>
  *
  *<pre>
 {@code

--- a/tests/test-extensions/net/sourceforge/jnlp/tools/CodeSignerCreator.java
+++ b/tests/test-extensions/net/sourceforge/jnlp/tools/CodeSignerCreator.java
@@ -204,7 +204,8 @@ public class CodeSignerCreator {
             String className = null;
             if (javaVersion.startsWith("1.7")) {
                 className = "sun.security.x509.CertAndKeyGen";
-            } else if (javaVersion.startsWith("1.8") || javaVersion.startsWith("1.9")) {
+            } else if (javaVersion.startsWith("1.8") ||
+                       javaVersion.matches("^(9|1[0-3])\\..*")) {
                 className = "sun.security.tools.keytool.CertAndKeyGen";
             } else {
                 throw new AssertionError("Unrecognized Java Version");


### PR DESCRIPTION
With this backporting, the 1.8 branch can also be built with java 11, 12 and 13, but only if the java plugin is disabled. This will certainly help some Linux package maintainers who are currently patching themselves to establish java 11 as the default java version in their distribution.