### PR TITLE
Refactoring: Basic Changes (renaming iteration variable, extracting StringFormatter Class, adding explaining variable in JNLP's SimpleRange class, and extracting Interrupted exception logging method)

### DIFF
--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/ProcessUtils.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/ProcessUtils.java
@@ -55,15 +55,21 @@ public class ProcessUtils {
         while (!pTerminated) {
             try {
                 process.waitFor();
-            } catch (final InterruptedException e) {
-                LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
-            }
-            try {
-                process.exitValue();
                 pTerminated = true;
-            } catch (final IllegalThreadStateException e) {
-                LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
+            } catch (final InterruptedException e) {
+                logInterruptedException(e);
             }
         }
     }
+
+    /**
+     * Logs the given InterruptedException to the error log using the default error message.
+     *
+     * @param e the InterruptedException object that occurred and will be logged
+     * @return This method does not have a return value as it logs the InterruptedException.
+     */
+    private static void logInterruptedException(InterruptedException e) {
+        LOG.error(IcedTeaWebConstants.DEFAULT_ERROR_MESSAGE, e);
+    }
+
 }

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/version/SimpleRange.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/jnlp/version/SimpleRange.java
@@ -44,6 +44,7 @@ import static net.adoptopenjdk.icedteaweb.jnlp.version.VersionModifier.PLUS;
  */
 class SimpleRange {
 
+    private static final String REGEXP_MODIFIER_END = REGEXP_MODIFIER + "$";
     private final VersionId versionId;
     private final VersionModifier modifier;
 
@@ -109,7 +110,7 @@ class SimpleRange {
     }
 
     private static VersionId extractVersionId(final String simpleRange) {
-        final String exactId = simpleRange.replaceAll(REGEXP_MODIFIER + "$", "");
+        final String exactId = simpleRange.replaceAll(REGEXP_MODIFIER_END, "");
         return VersionId.fromString(exactId);
     }
 

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  */
 public abstract class BaseLogger implements Logger {
 
-    protected String expand(final String msg, final Object[] args) {
+    protected static String expand(final String msg, final Object[] args) {
         return new StringFormatter().expand(msg, args);
     }
 }

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
@@ -9,10 +9,12 @@ import java.util.Objects;
 public abstract class BaseLogger implements Logger {
 
     protected String expand(final String msg, final Object[] args) {
-        return doExpand(msg, args);
+        return new StringFormatter().expand(msg, args);
     }
+}
 
-    static String doExpand(final String msg, final Object[] args) {
+class StringFormatter {
+    String expand(final String msg, final Object[] args) {
         if (msg == null) {
             return "null";
         }

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
@@ -8,13 +8,13 @@ import java.util.Objects;
  */
 public abstract class BaseLogger implements Logger {
 
-    protected String expand(final String msg, final Object[] args) {
-        return new StringFormatter().expand(msg, args);
+    protected static String doExpand(final String msg, final Object[] args) {
+        return new StringFormatter().doExpand(msg, args);
     }
 }
 
 class StringFormatter {
-    String expand(final String msg, final Object[] args) {
+    String doExpand(final String msg, final Object[] args) {
         if (msg == null) {
             return "null";
         }

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/BaseLogger.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  */
 public abstract class BaseLogger implements Logger {
 
-    protected static String expand(final String msg, final Object[] args) {
+    protected String expand(final String msg, final Object[] args) {
         return new StringFormatter().expand(msg, args);
     }
 }

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/SystemOutLoggerFactory.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/logging/SystemOutLoggerFactory.java
@@ -47,7 +47,7 @@ class SystemOutLoggerFactory implements LoggerFactoryImpl {
 
         @Override
         public void debug(final String msg, final Object... arguments) {
-            log(DEBUG, expand(msg, arguments), null);
+            log(DEBUG, doExpand(msg, arguments), null);
         }
 
         @Override
@@ -62,7 +62,7 @@ class SystemOutLoggerFactory implements LoggerFactoryImpl {
 
         @Override
         public void info(final String msg, final Object... arguments) {
-            log(INFO, expand(msg, arguments), null);
+            log(INFO, doExpand(msg, arguments), null);
         }
 
         @Override
@@ -77,7 +77,7 @@ class SystemOutLoggerFactory implements LoggerFactoryImpl {
 
         @Override
         public void warn(final String msg, final Object... arguments) {
-            log(WARNING, expand(msg, arguments), null);
+            log(WARNING, doExpand(msg, arguments), null);
         }
 
         @Override
@@ -92,7 +92,7 @@ class SystemOutLoggerFactory implements LoggerFactoryImpl {
 
         @Override
         public void error(final String msg, final Object... arguments) {
-            log(ERROR, expand(msg, arguments), null);
+            log(ERROR, doExpand(msg, arguments), null);
         }
 
         @Override

--- a/common/src/main/java/net/adoptopenjdk/icedteaweb/validator/DirectoryCheckResults.java
+++ b/common/src/main/java/net/adoptopenjdk/icedteaweb/validator/DirectoryCheckResults.java
@@ -27,14 +27,14 @@ public class DirectoryCheckResults {
      * @return sum of passed checks, 0-3 per result
      */
     public int getPasses() {
-        return results.stream().mapToInt(r -> r.getPasses()).sum();
+        return results.stream().mapToInt(result -> result.getPasses()).sum();
     }
 
     /**
      * @return sum of failed checks, 0-3 per results
      */
     public int getFailures() {
-        return results.stream().mapToInt(r -> r.getFailures()).sum();
+        return results.stream().mapToInt(result -> result.getFailures()).sum();
     }
 
     /**
@@ -60,9 +60,9 @@ public class DirectoryCheckResults {
 
     private static String resultsToString(final List<DirectoryCheckResult> results) {
         final StringBuilder sb = new StringBuilder();
-        for (final DirectoryCheckResult r : results) {
-            if (r.getFailures() > 0) {
-                sb.append(r.getMessage());
+        for (final DirectoryCheckResult result : results) {
+            if (result.getFailures() > 0) {
+                sb.append(result.getMessage());
             }
         }
         return sb.toString();

--- a/common/src/test/java/net/adoptopenjdk/icedteaweb/logging/BaseLoggerTest.java
+++ b/common/src/test/java/net/adoptopenjdk/icedteaweb/logging/BaseLoggerTest.java
@@ -11,7 +11,7 @@ public class BaseLoggerTest {
         final String message = null;
         final Object[] args = {"ONE"};
 
-        assertThat(BaseLogger.expand(message, args), is("null"));
+        assertThat(BaseLogger.doExpand(message, args), is("null"));
     }
 
     @Test
@@ -19,7 +19,7 @@ public class BaseLoggerTest {
         final String message = "Message without arguments stay unchanged.";
         final Object[] args = {};
 
-        assertThat(BaseLogger.expand(message, args), is("Message without arguments stay unchanged."));
+        assertThat(BaseLogger.doExpand(message, args), is("Message without arguments stay unchanged."));
     }
 
     @Test
@@ -27,7 +27,7 @@ public class BaseLoggerTest {
         final String message = "Message with null arguments stay unchanged.";
         final Object[] args = null;
 
-        assertThat(BaseLogger.expand(message, args), is("Message with null arguments stay unchanged."));
+        assertThat(BaseLogger.doExpand(message, args), is("Message with null arguments stay unchanged."));
     }
 
     @Test
@@ -35,7 +35,7 @@ public class BaseLoggerTest {
         final String message = "This is a message with {} argument.";
         final Object[] args = {"ONE"};
 
-        assertThat(BaseLogger.expand(message, args), is("This is a message with ONE argument."));
+        assertThat(BaseLogger.doExpand(message, args), is("This is a message with ONE argument."));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class BaseLoggerTest {
         final String message = "This is a message with the arguments {} and {}.";
         final Object[] args = {"ONE", 2};
 
-        assertThat(BaseLogger.expand(message, args), is("This is a message with the arguments ONE and 2."));
+        assertThat(BaseLogger.doExpand(message, args), is("This is a message with the arguments ONE and 2."));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class BaseLoggerTest {
         final String message = "This is a message with the arguments {} and {}.";
         final Object[] args = {"ONE", 2, "abc"};
 
-        assertThat(BaseLogger.expand(message, args), is("This is a message with the arguments ONE and 2."));
+        assertThat(BaseLogger.doExpand(message, args), is("This is a message with the arguments ONE and 2."));
     }
 
     @Test
@@ -59,6 +59,6 @@ public class BaseLoggerTest {
         final String message = "This is a message with the arguments {} and {}.";
         final Object[] args = {"ONE"};
 
-        assertThat(BaseLogger.expand(message, args), is("This is a message with the arguments ONE and {}."));
+        assertThat(BaseLogger.doExpand(message, args), is("This is a message with the arguments ONE and {}."));
     }
 }

--- a/common/src/test/java/net/adoptopenjdk/icedteaweb/logging/BaseLoggerTest.java
+++ b/common/src/test/java/net/adoptopenjdk/icedteaweb/logging/BaseLoggerTest.java
@@ -11,7 +11,7 @@ public class BaseLoggerTest {
         final String message = null;
         final Object[] args = {"ONE"};
 
-        assertThat(BaseLogger.doExpand(message, args), is("null"));
+        assertThat(BaseLogger.expand(message, args), is("null"));
     }
 
     @Test
@@ -19,7 +19,7 @@ public class BaseLoggerTest {
         final String message = "Message without arguments stay unchanged.";
         final Object[] args = {};
 
-        assertThat(BaseLogger.doExpand(message, args), is("Message without arguments stay unchanged."));
+        assertThat(BaseLogger.expand(message, args), is("Message without arguments stay unchanged."));
     }
 
     @Test
@@ -27,7 +27,7 @@ public class BaseLoggerTest {
         final String message = "Message with null arguments stay unchanged.";
         final Object[] args = null;
 
-        assertThat(BaseLogger.doExpand(message, args), is("Message with null arguments stay unchanged."));
+        assertThat(BaseLogger.expand(message, args), is("Message with null arguments stay unchanged."));
     }
 
     @Test
@@ -35,7 +35,7 @@ public class BaseLoggerTest {
         final String message = "This is a message with {} argument.";
         final Object[] args = {"ONE"};
 
-        assertThat(BaseLogger.doExpand(message, args), is("This is a message with ONE argument."));
+        assertThat(BaseLogger.expand(message, args), is("This is a message with ONE argument."));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class BaseLoggerTest {
         final String message = "This is a message with the arguments {} and {}.";
         final Object[] args = {"ONE", 2};
 
-        assertThat(BaseLogger.doExpand(message, args), is("This is a message with the arguments ONE and 2."));
+        assertThat(BaseLogger.expand(message, args), is("This is a message with the arguments ONE and 2."));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class BaseLoggerTest {
         final String message = "This is a message with the arguments {} and {}.";
         final Object[] args = {"ONE", 2, "abc"};
 
-        assertThat(BaseLogger.doExpand(message, args), is("This is a message with the arguments ONE and 2."));
+        assertThat(BaseLogger.expand(message, args), is("This is a message with the arguments ONE and 2."));
     }
 
     @Test
@@ -59,6 +59,6 @@ public class BaseLoggerTest {
         final String message = "This is a message with the arguments {} and {}.";
         final Object[] args = {"ONE"};
 
-        assertThat(BaseLogger.doExpand(message, args), is("This is a message with the arguments ONE and {}."));
+        assertThat(BaseLogger.expand(message, args), is("This is a message with the arguments ONE and {}."));
     }
 }


### PR DESCRIPTION
Hello,

In these commits, I have performed some basic refactoring. The changes include:
1. Renaming iterationg variable: For better redability (b11d1a44b41bc1df9d756521a5641af5303a721d)
2. Extracting StringFormatter Class from BaseLogger (8aa11c261b1feb0b332fbf86133927e083f187e7, e305bef4fe4fd1fdcf13e5c9d3f593929ab29633, 3bda7238d76c85336ab252f8b08a463b07c715dd)
3. Adding an explaining variable in JNLP's SimpleRange class (55275aa4d2d1ca140b118bb3c33c4494f0d03226)
4. Extracted Interrupted exception logging method (a6b4efd716e40248a29ffe894699cb73f7a12aa7)