### PR TITLE
Use same naming scheme like bash-completion

### DIFF
--- a/launchers/utils.sh
+++ b/launchers/utils.sh
@@ -170,7 +170,7 @@ function sedBashCompletion() {
   mkdir -p $BASHD_TARGET
   OPTIONS=`$OPTIONS_COMMAND $1`; \
   echo $OPTIONS ; \
-  cat $SCRIPT_DIR/completion.in/$1.bash.in |   sed "s/@OPTIONS@/${OPTIONS}/" > $BASHD_TARGET/$1.bash
+  cat $SCRIPT_DIR/completion.in/$1.bash.in | sed "s/@OPTIONS@/${OPTIONS}/" > $BASHD_TARGET/$1
 }
 
 function sedDesktopIcons() {


### PR DESCRIPTION
As of writing, all bash-completion files installed by IcedTea-Web are named e.g. `/usr/share/bash-completion/completions/javaws.bash` while bash-completion itself uses a naming scheme without `.bash`, thus e.g. `/usr/share/bash-completion/completions/javaws` would conform upstream's naming scheme.

Example file lists from downstreams packaging bash-completion:
- Fedora: https://packages.fedoraproject.org/pkgs/bash-completion/bash-completion/fedora-rawhide.html#files
- Debian: https://packages.debian.org/sid/all/bash-completion/filelist