### PR TITLE
Use same naming scheme like bash-completion (backport for 1.8)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -416,9 +416,9 @@ if WINDOWS_OR_INCLUDE_BATS
 	${INSTALL_PROGRAM} launcher.build/$(policyeditor).bat $(DESTDIR)$(bindir)
 endif
 endif
-	${INSTALL_DATA} $(TOP_BUILD_DIR)/completion/itweb-settings.bash $(BASH_CMPL_DEST_DIR)/
-	${INSTALL_DATA} $(TOP_BUILD_DIR)/completion/javaws.bash $(BASH_CMPL_DEST_DIR)/
-	${INSTALL_DATA} $(TOP_BUILD_DIR)/completion/policyeditor.bash $(BASH_CMPL_DEST_DIR)/
+	${INSTALL_DATA} $(TOP_BUILD_DIR)/completion/itweb-settings.bash $(BASH_CMPL_DEST_DIR)/itweb-settings
+	${INSTALL_DATA} $(TOP_BUILD_DIR)/completion/javaws.bash $(BASH_CMPL_DEST_DIR)/javaws
+	${INSTALL_DATA} $(TOP_BUILD_DIR)/completion/policyeditor.bash $(BASH_CMPL_DEST_DIR)/policyeditor
 
 # all generated manpages are installed in swarm
 # all windows depndences are copied for windows build, and known one are copied/removed as necessary


### PR DESCRIPTION
This is a backport of #898 for 1.8.

As of writing, all bash-completion files installed by IcedTea-Web are named e.g. `/usr/share/bash-completion/completions/javaws.bash` while bash-completion itself uses a naming scheme without `.bash`, thus e.g. `/usr/share/bash-completion/completions/javaws` would conform upstream's naming scheme.

Example file lists from downstreams packaging bash-completion:
- Fedora: https://packages.fedoraproject.org/pkgs/bash-completion/bash-completion/fedora-rawhide.html#files
- Debian: https://packages.debian.org/sid/all/bash-completion/filelist