### PR TITLE
Disable man pages for languages without any translation (1.8)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -899,7 +899,7 @@ stamps/generate-docs.stamp: stamps/netx.stamp
 	LANG_BACKUP=$$LANG ; \
 	echo "<html><head><title>$(PLUGIN_VERSION)</title></head>" > "$$HTML_DOCS_INDEX" ; \
 	echo "<body><h3>$(PLUGIN_VERSION) docs:</h3>"  >> "$$HTML_DOCS_INDEX" ; \
-	for LANG_ID in en_US.UTF-8 cs_CZ.UTF-8 pl_PL.UTF-8 de_DE.UTF-8 ;  do \
+	for LANG_ID in en_US.UTF-8 ;  do \
 	  ID=`echo "$$LANG_ID" | head -c 2` ; \
 	  ENCOD=`echo "$$LANG_ID" | tail -c 6 -` ; \
 	  export LANG=$$LANG_ID; \


### PR DESCRIPTION
I can not see any benefit of shipping man pages for Czech, German and Polish, which are actually (for multiple years) identical to the English ones. For me it looks currently like this:

```
44ced6c832ec1188fc179fe00f014fa5975990e9188348f7a01046de65fc081f  /usr/share/man/man1/itweb-settings.1.gz
44ced6c832ec1188fc179fe00f014fa5975990e9188348f7a01046de65fc081f  /usr/share/man/cs/man1/itweb-settings.1.gz
44ced6c832ec1188fc179fe00f014fa5975990e9188348f7a01046de65fc081f  /usr/share/man/de/man1/itweb-settings.1.gz
44ced6c832ec1188fc179fe00f014fa5975990e9188348f7a01046de65fc081f  /usr/share/man/pl/man1/itweb-settings.1.gz
261ade9ffe38d8091a8e8350660329791e43ed9041cdf09a7f15dd40b6c86802  /usr/share/man/man1/icedtea-web.1.gz
261ade9ffe38d8091a8e8350660329791e43ed9041cdf09a7f15dd40b6c86802  /usr/share/man/cs/man1/icedtea-web.1.gz
261ade9ffe38d8091a8e8350660329791e43ed9041cdf09a7f15dd40b6c86802  /usr/share/man/de/man1/icedtea-web.1.gz
261ade9ffe38d8091a8e8350660329791e43ed9041cdf09a7f15dd40b6c86802  /usr/share/man/pl/man1/icedtea-web.1.gz
3908b33038a94803d611ce158743752f4638b8d668cfa1c7d1a0e42f5887d1f5  /usr/share/man/man1/javaws.1.gz
3908b33038a94803d611ce158743752f4638b8d668cfa1c7d1a0e42f5887d1f5  /usr/share/man/cs/man1/javaws.1.gz
3908b33038a94803d611ce158743752f4638b8d668cfa1c7d1a0e42f5887d1f5  /usr/share/man/de/man1/javaws.1.gz
3908b33038a94803d611ce158743752f4638b8d668cfa1c7d1a0e42f5887d1f5  /usr/share/man/pl/man1/javaws.1.gz
d5aabac83ce25981daf507285436938233e2c828e0c4b36c8c10a0231f8a90a2  /usr/share/man/man1/icedtea-web-plugin.1.gz
d5aabac83ce25981daf507285436938233e2c828e0c4b36c8c10a0231f8a90a2  /usr/share/man/cs/man1/icedtea-web-plugin.1.gz
d5aabac83ce25981daf507285436938233e2c828e0c4b36c8c10a0231f8a90a2  /usr/share/man/de/man1/icedtea-web-plugin.1.gz
d5aabac83ce25981daf507285436938233e2c828e0c4b36c8c10a0231f8a90a2  /usr/share/man/pl/man1/icedtea-web-plugin.1.gz
b2ee037d12d28baf1dc06aa30ccd784f5b375d6660e79315453e638cf0f74143  /usr/share/man/man1/policyeditor.1.gz
b2ee037d12d28baf1dc06aa30ccd784f5b375d6660e79315453e638cf0f74143  /usr/share/man/cs/man1/policyeditor.1.gz
b2ee037d12d28baf1dc06aa30ccd784f5b375d6660e79315453e638cf0f74143  /usr/share/man/de/man1/policyeditor.1.gz
b2ee037d12d28baf1dc06aa30ccd784f5b375d6660e79315453e638cf0f74143  /usr/share/man/pl/man1/policyeditor.1.gz
```

As conclusion I propose to disable man pages for languages without any translation.