### PR TITLE
Disable sun.applet javadocs and plugin man page for --disable-pluginjar (1.8)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -241,8 +241,7 @@ export NETX_PKGS = javax.jnlp net.sourceforge.nanoxml net.sourceforge.jnlp \
 	net.sourceforge.jnlp.controlpanel net.sourceforge.jnlp.event \
 	net.sourceforge.jnlp.runtime net.sourceforge.jnlp.security \
 	net.sourceforge.jnlp.security.viewer net.sourceforge.jnlp.services \
-	net.sourceforge.jnlp.tools net.sourceforge.jnlp.util \
-	sun.applet
+	net.sourceforge.jnlp.tools net.sourceforge.jnlp.util
 
 if ENABLE_PLUGINJAR
 export ICEDTEAPLUGIN_TARGET = stamps/liveconnect-dist.stamp
@@ -251,6 +250,7 @@ export PLUGIN_SRCDIR=$(TOP_SRC_DIR)/plugin/icedteanp
 export JSOBJECT_DIRS = netscape
 export SUN_DIR = sun
 export SUN_APPLET_DIRS = sun/applet
+export SUN_APPLET_PKGS = sun.applet
 export PLUGIN_PKGS = sun.applet netscape.security netscape.javascript
 export LIVECONNECT_SRCS = $(PLUGIN_SRCDIR)/java
 export LIVECONNECT_DIR = $(JSOBJECT_DIRS) $(SUN_APPLET_DIRS)
@@ -898,7 +898,7 @@ stamps/generate-docs.stamp: stamps/netx.stamp
 	mkdir "$$PLAIN_DOCS_TARGET_DIR" ; \
 	mkdir "$$MAN_DOCS_TARGET_DIR" ; \
 	HTML_DOCS_INDEX="$$HTML_DOCS_TARGET_DIR/index.html" ; \
-	TP_COMMAND="$(SYSTEM_JRE_DIR)/bin/java -cp $(NETX_DIR) net.sourceforge.jnlp.util.docprovider.TextsProvider" ; \
+	TP_COMMAND="$(SYSTEM_JRE_DIR)/bin/java --add-exports=java.base/sun.security.action=ALL-UNNAMED -DPLUGIN_JAR=$(PLUGIN_JAR) -cp $(NETX_DIR) net.sourceforge.jnlp.util.docprovider.TextsProvider" ; \
 	TP_TAIL="false $(FULL_VERSION)" ; \
 	LANG_BACKUP=$$LANG ; \
 	echo "<html><head><title>$(PLUGIN_VERSION)</title></head>" > "$$HTML_DOCS_INDEX" ; \
@@ -1189,7 +1189,7 @@ if ENABLE_DOCS
 	 -windowtitle 'IcedTea-Web: NetX ' \
 	 -header '<strong>IcedTea-Web<br/>NetX</strong>' \
 	 $(call composeclasspath, $(MSLINKS_JAR) $(TAGSOUP_JAR) $(RHINO_JAR)) \
-	 $(NETX_PKGS)
+	 $(NETX_PKGS) $(SUN_APPLET_PKGS)
 endif
 	mkdir -p stamps
 	touch stamps/netx-docs.stamp

--- a/netx/net/sourceforge/jnlp/util/docprovider/TextsProvider.java
+++ b/netx/net/sourceforge/jnlp/util/docprovider/TextsProvider.java
@@ -498,12 +498,14 @@ public abstract class TextsProvider {
                 os.flush();
             }
         }
-        JavaWsTextsProvider javaws = new JavaWsTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand);
-        ItwebSettingsTextsProvider itws = new ItwebSettingsTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand);
-        PolicyEditorTextsProvider pe = new PolicyEditorTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand);
-        IcedTeaWebTextsProvider itw = new IcedTeaWebTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand);
-        ItwebPluginTextProvider pl = new ItwebPluginTextProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand);
-        TextsProvider[] providers = new TextsProvider[]{javaws, itws, pe, itw, pl};
+        ArrayList<TextsProvider> providers = new ArrayList<TextsProvider>();
+        providers.add(new JavaWsTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand));
+        providers.add(new ItwebSettingsTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand));
+        providers.add(new PolicyEditorTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand));
+        providers.add(new IcedTeaWebTextsProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand));
+        if (!System.getProperty("PLUGIN_JAR", "").isEmpty()) {
+            providers.add(new ItwebPluginTextProvider(encoding, new HtmlFormatter(allowContext, allowLogo, includeXmlHeader), titles, expand));
+        }
         for (TextsProvider provider : providers) {
             provider.setAuthorFilePath(authorFileFromUserInput);
             provider.writeToDir(dir);
@@ -516,12 +518,14 @@ public abstract class TextsProvider {
     }
 
     public static void generateManText(String encoding, File dir, boolean titles, boolean expand) throws IOException {
-        JavaWsTextsProvider javaws = new JavaWsTextsProvider(encoding, new ManFormatter(), titles, expand);
-        ItwebSettingsTextsProvider itws = new ItwebSettingsTextsProvider(encoding, new ManFormatter(), titles, expand);
-        PolicyEditorTextsProvider pe = new PolicyEditorTextsProvider(encoding, new ManFormatter(), titles, expand);
-        IcedTeaWebTextsProvider itw = new IcedTeaWebTextsProvider(encoding, new ManFormatter(), titles, expand);
-        ItwebPluginTextProvider pl = new ItwebPluginTextProvider(encoding, new ManFormatter(), titles, expand);
-        TextsProvider[] providers = new TextsProvider[]{javaws, itws, pe, itw, pl};
+        ArrayList<TextsProvider> providers = new ArrayList<TextsProvider>();
+        providers.add(new JavaWsTextsProvider(encoding, new ManFormatter(), titles, expand));
+        providers.add(new ItwebSettingsTextsProvider(encoding, new ManFormatter(), titles, expand));
+        providers.add(new PolicyEditorTextsProvider(encoding, new ManFormatter(), titles, expand));
+        providers.add(new IcedTeaWebTextsProvider(encoding, new ManFormatter(), titles, expand));
+        if (!System.getProperty("PLUGIN_JAR", "").isEmpty()) {
+            providers.add(new ItwebPluginTextProvider(encoding, new ManFormatter(), titles, expand));
+        }
         for (TextsProvider provider : providers) {
             provider.setAuthorFilePath(authorFileFromUserInput);
             provider.writeToDir(dir);
@@ -534,12 +538,14 @@ public abstract class TextsProvider {
     }
 
     public static void generatePlainTextDocs(String encoding, File dir, String indent, int lineWidth, boolean titles, boolean expand) throws IOException {
-        JavaWsTextsProvider javaws = new JavaWsTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand);
-        ItwebSettingsTextsProvider itws = new ItwebSettingsTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand);
-        PolicyEditorTextsProvider pe = new PolicyEditorTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand);
-        IcedTeaWebTextsProvider itw = new IcedTeaWebTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand);
-        ItwebPluginTextProvider pl = new ItwebPluginTextProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand);
-        TextsProvider[] providers = new TextsProvider[]{javaws, itws, pe, itw, pl};
+        ArrayList<TextsProvider> providers = new ArrayList<TextsProvider>();
+        providers.add(new JavaWsTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand));
+        providers.add(new ItwebSettingsTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand));
+        providers.add(new PolicyEditorTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand));
+        providers.add(new IcedTeaWebTextsProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand));
+        if (!System.getProperty("PLUGIN_JAR", "").isEmpty()) {
+            providers.add(new ItwebPluginTextProvider(encoding, new PlainTextFormatter(indent, lineWidth), titles, expand));
+        }
         for(TextsProvider provider : providers){
             provider.setAuthorFilePath(authorFileFromUserInput);
             provider.writeToDir(dir);


### PR DESCRIPTION
As of writing, `./configure --disable-pluginjar` still leads to `sun.applet` being handled for javadocs and the plugin man page gets generated, too. From my point of view, both shouldn't be the case.

I also needed to add `--add-exports=java.base/sun.security.action=ALL-UNNAMED` to avoid running in the exception below when using OpenJDK Java 17:

```
Exception in thread "main" java.lang.IllegalAccessError: class net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter (in unnamed module @0x8efb846) cannot access class sun.security.action.GetPropertyAction (in module java.base) because module java.base does not export sun.security.action to unnamed module @0x8efb846
	at net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter.getLineSeparator(PlainTextFormatter.java:55)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStringReal(TextsProvider.java:326)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.prepare(TextsProvider.java:312)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToString(TextsProvider.java:320)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToWriter(TextsProvider.java:379)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStream(TextsProvider.java:386)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToFile(TextsProvider.java:392)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToDir(TextsProvider.java:398)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateHtmlTexts(TextsProvider.java:511)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateHtmlTextsUtf8(TextsProvider.java:489)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateHtmlTexts(TextsProvider.java:485)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateOnlineHtmlHelp(TextsProvider.java:481)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.main(TextsProvider.java:440)
Exception in thread "main" java.lang.IllegalAccessError: class net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter (in unnamed module @0x76ed5528) cannot access class sun.security.action.GetPropertyAction (in module java.base) because module java.base does not export sun.security.action to unnamed module @0x76ed5528
	at net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter.getLineSeparator(PlainTextFormatter.java:55)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStringReal(TextsProvider.java:326)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.prepare(TextsProvider.java:312)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToString(TextsProvider.java:320)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToWriter(TextsProvider.java:379)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStream(TextsProvider.java:386)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToFile(TextsProvider.java:392)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToDir(TextsProvider.java:398)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generatePlainTextDocs(TextsProvider.java:551)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generatePlainTextDocs(TextsProvider.java:537)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.main(TextsProvider.java:449)
Exception in thread "main" java.lang.IllegalAccessError: class net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter (in unnamed module @0x8efb846) cannot access class sun.security.action.GetPropertyAction (in module java.base) because module java.base does not export sun.security.action to unnamed module @0x8efb846
	at net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter.getLineSeparator(PlainTextFormatter.java:55)
	at net.sourceforge.jnlp.util.docprovider.formatters.formatters.ManFormatter.getHeaders(ManFormatter.java:111)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.getHeader(TextsProvider.java:102)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStringReal(TextsProvider.java:325)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.prepare(TextsProvider.java:312)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToString(TextsProvider.java:320)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToWriter(TextsProvider.java:379)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStream(TextsProvider.java:386)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToFile(TextsProvider.java:392)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToDir(TextsProvider.java:398)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateManText(TextsProvider.java:531)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateManText(TextsProvider.java:517)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.main(TextsProvider.java:446)
Exception in thread "main" java.lang.IllegalAccessError: class net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter (in unnamed module @0x4517d9a3) cannot access class sun.security.action.GetPropertyAction (in module java.base) because module java.base does not export sun.security.action to unnamed module @0x4517d9a3
	at net.sourceforge.jnlp.util.docprovider.formatters.formatters.PlainTextFormatter.getLineSeparator(PlainTextFormatter.java:55)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStringReal(TextsProvider.java:326)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.prepare(TextsProvider.java:312)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToString(TextsProvider.java:320)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToWriter(TextsProvider.java:379)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToStream(TextsProvider.java:386)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.writeToFile(TextsProvider.java:392)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.generateItwIntro(TextsProvider.java:463)
	at net.sourceforge.jnlp.util.docprovider.TextsProvider.main(TextsProvider.java:443)
```