### PR TITLE
Fix javadoc error related to @param in TimedHashMap.java (1.8)

### DIFF
--- a/netx/net/sourceforge/jnlp/util/TimedHashMap.java
+++ b/netx/net/sourceforge/jnlp/util/TimedHashMap.java
@@ -57,8 +57,8 @@ import net.sourceforge.jnlp.util.logging.OutputController;
  * 
  * This map does not allow null keys but does allow null values.
  *
- * @param K The key type
- * @param V The Object type
+ * @param <K> The key type
+ * @param <V> The Object type
  */
 public class TimedHashMap<K, V> implements Map<K, V> {
 


### PR DESCRIPTION
When building using OpenJDK Java 17, I run into the following javadoc error related to `@param` in `TimedHashMap.java` which should be fixed:

```
IcedTea-Web-icedtea-web-1.8.8/netx/net/sourceforge/jnlp/util/TimedHashMap.java:60: error: invalid use of @param
 * @param K The key type
   ^
IcedTea-Web-icedtea-web-1.8.8/netx/net/sourceforge/jnlp/util/TimedHashMap.java:61: error: invalid use of @param
 * @param V The Object type
   ^
```