### PR TITLE
Fix of Issue #913 Missing java-vm-args to use ShenandoahGC

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jvm/JvmUtils.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jvm/JvmUtils.java
@@ -186,7 +186,9 @@ public class JvmUtils {
                 "-XX:+ScavengeBeforeFullGC",
                 "-XX:-ScavengeBeforeFullGC",
                 "-XX:+UseParallelScavenge",
-                "-XX:-UseParallelScavenge"
+                "-XX:-UseParallelScavenge",
+                "-XX:+UseShenandoahGC",
+                "-XX:-UseShenandoahGC"
         };
     }
 


### PR DESCRIPTION
Add java-vm-args to use ShenandoahGC 

In the JNLP file I set the [Shenandoah GC](https://wiki.openjdk.org/display/shenandoah/Main)
with the vm-args:

<j2se version="17*" vendor="*" java-vm-args="-Xmx3g -Xms1g -XX:+UseShenandoahGC"/>
but I got the warning:

[ITW-CORE][WARN ][net.sourceforge.jnlp.Parser] Ignoring java-vm-args due to illegal Property -XX:+UseShenandoahGC