### PR TITLE
Add additional valid starting VM arguments

### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/jvm/JvmUtils.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/jvm/JvmUtils.java
@@ -239,7 +239,10 @@ public class JvmUtils {
                 "-XX:GCTimeLimit",
                 "-XX:GCHeapFreeLimit",
                 "-XX:+UseParNewGC",
-                "-XX:+CMSParallelRemarkEnabled"
+                "-XX:+CMSParallelRemarkEnabled",
+                "-XX:InitialRAMPercentage", /* The initial heap size as percentage of total memory, conflicts with Xms */
+                "-XX:MinRAMPercentage", /* Sets the max heap size of RAM as a percentage before looking at other heuristics like MaxRAMPercentage. This is primarily useful for low memory environments (<100m) */
+                "-XX:MaxRAMPercentage", /* Sets the max heap size of RAM as a percentage */
         };
     }
 


### PR DESCRIPTION
These were introduced in Java 8u191 (2018-10-16).

An important note on `MinRAMPercentage`: it is only used on ''small'' heap sizes (think <100M). It is primarily used for container applications.

The properties match the following requirements:
* No `"` or `%` character (the double values do not include `%`)
* Values include `.` (0x2E) and 0-9 (0x30-0x39); that is between `0x20` and `0x17E`
* The strings do not include `\`

While these properties were originally introduced for containers, they are also useful for desktop applications. Of specific note, `MaxRAMPercentage` is useful for applications that can have a _small_ amount of data in memory to a _large_ amount of data in memory.

Default values:
* InitialRAMPercentage: 1.5625
* MinRamPercentage: 50.0
* MaxRamPercentage: 25.0