### PR TITLE
Work around usage of CachedJarFileCallback

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
+++ b/core/src/main/java/net/sourceforge/jnlp/runtime/JNLPRuntime.java
@@ -41,7 +41,6 @@ import net.sourceforge.jnlp.services.XServiceManagerStub;
 import net.sourceforge.jnlp.util.RestrictedFileUtils;
 import net.sourceforge.jnlp.util.logging.LogConfig;
 import net.sourceforge.jnlp.util.logging.OutputController;
-import sun.net.www.protocol.jar.URLJarFile;
 
 import javax.jnlp.ServiceManager;
 import javax.naming.ConfigurationException;
@@ -299,8 +298,6 @@ public class JNLPRuntime {
         // Restrict access to netx classes
         Security.setProperty("package.access",
                              Security.getProperty("package.access")+",net.sourceforge.jnlp");
-
-        URLJarFile.setCallBack(CachedJarFileCallback.getInstance());
 
         initialized = true;
         LOG.debug("End JNLPRuntime.initialize()");

--- a/core/src/test/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoaderTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/runtime/classloader/JNLPClassLoaderTest.java
@@ -84,7 +84,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @NotThreadSafe
 @Ignore
@@ -555,7 +554,6 @@ public class JNLPClassLoaderTest extends NoStdOutErrTest {
         JNLPRuntime.setSecurityEnabled(false);
         JNLPRuntime.setDebug(true);
         getConfiguration().setProperty(ConfigurationConstants.KEY_ENABLE_MANIFEST_ATTRIBUTES_CHECK, "NONE");
-        URLJarFile.setCallBack(CachedJarFileCallback.getInstance());
 
         final ServerLauncher as = ServerAccess.getIndependentInstance(jnlp.getParent(), port);
         try {
@@ -569,7 +567,6 @@ public class JNLPClassLoaderTest extends NoStdOutErrTest {
             JNLPRuntime.setSecurityEnabled(securityBackup);
             JNLPRuntime.setDebug(verbose);
             getConfiguration().setProperty(ConfigurationConstants.KEY_ENABLE_MANIFEST_ATTRIBUTES_CHECK, manifestAttsBackup);
-            URLJarFile.setCallBack(null);
             as.stop();
 
             clearCache();


### PR DESCRIPTION
In Java24 the interface URLJarFileCallBack is removed as well as the mechanism behind it. This mechanism allows to intercept the download of a JAR in for example a class loader to add custom logic. Because of us setting CachedJarFileCallback actively and that class implementing the now no longer available interface the execution on Java 24 fails with a ClassNotFoundException.
This PR tries to keep the mechanism for the class loader as good as possible by using the tracker logic directly and removes the callbacks. 

One disadvantage is that the class loader no longer shows the remote URLs in the classpath.
