### PR TITLE
Extend JAVADOC_OPTS for Java 21+ (1.8)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -287,7 +287,15 @@ if ENABLE_DOCS
 JAVADOC_OPTS=-use -keywords -encoding UTF-8 -splitIndex \
  -bottom '<font size="-1"> <a href="http://icedtea.classpath.org/bugzilla">Submit a bug or feature</a></font>'
 if HAVE_JAVA9
-JAVADOC_OPTS+=-source $(IT_LANGUAGE_SOURCE_VERSION) --ignore-source-errors
+JAVADOC_OPTS+=-source $(IT_LANGUAGE_SOURCE_VERSION)
+endif
+if HAVE_JAVA21
+JAVADOC_OPTS+=--add-exports=java.base/sun.security.provider=ALL-UNNAMED
+JAVADOC_OPTS+=--add-exports=java.base/sun.security.util=ALL-UNNAMED
+JAVADOC_OPTS+=--add-exports=java.base/sun.security.validator=ALL-UNNAMED
+JAVADOC_OPTS+=--add-exports=java.base/sun.security.x509=ALL-UNNAMED
+JAVADOC_OPTS+=--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+JAVADOC_OPTS+=--add-exports=java.desktop/sun.awt=ALL-UNNAMED
 endif
 if JAVADOC_SUPPORTS_J_OPTIONS
 JAVADOC_MEM_OPTS=-J-Xmx1024m -J-Xms128m


### PR DESCRIPTION
https://salsa.debian.org/java-team/icedtea-web/-/blob/master/debian/patches/jdk-21-autoconf.patch is a prerequisite, allows removing `--ignore-source-errors` from `JAVADOC_OPTS` being introduced with commit be989488bb60c23b8ea2b5e95282d661d25a4077.