### PR TITLE
Prepend -Djava.security.manager as workaround for Java 21 (1.8)

### DIFF
--- a/rust-launcher/src/main.rs
+++ b/rust-launcher/src/main.rs
@@ -172,6 +172,7 @@ fn compose_arguments(java_dir: &std::path::PathBuf, original_args: &std::vec::Ve
     all_args.push(cp);
     all_args.push(bin_name);
     all_args.push(bin_location);
+    all_args.push(String::from("-Djava.security.manager"));
     all_args.push(hardcoded_paths::get_main().to_string());
 
     include_not_dashJs(&original_args, &mut all_args);

--- a/shell-launcher/launchers.sh.in
+++ b/shell-launcher/launchers.sh.in
@@ -188,6 +188,9 @@ k=$((k+1))
 COMMAND[k]="-Dicedtea-web.bin.location=${BINARY_LOCATION}"
 k=$((k+1))
 
+COMMAND[k]="-Djava.security.manager"
+k=$((k+1))
+
 COMMAND[k]="${CLASSNAME}"
 k=$((k+1))
 j=0


### PR DESCRIPTION
The Java security manager is deprecated since Java 17 and disabled by default since at least Java 21 (and subject to removal in a future release). For the time being enabling the security manager (as a workaround) leads to a working IcedTea-Web using Java 21.

Inspired by https://salsa.debian.org/java-team/icedtea-web/-/blob/master/debian/patches/javaws_change_java_policy.diff