### PR TITLE
Fix channel encoding in browser plugin to be compatible with newer Glib versions

### DIFF
--- a/plugin/icedteanp/IcedTeaNPPlugin.cc
+++ b/plugin/icedteanp/IcedTeaNPPlugin.cc
@@ -631,7 +631,7 @@ NPError start_jvm_if_needed()
   in_from_appletviewer = g_io_channel_new_file (in_pipe_name,
                                                       "r", &channel_error);
   // Setting encoding to binary so plugin does not crash when reading line in plugin_in_pipe_callback() for newer GLib versions
-  g_io_channel_set_encoding (in_from_appletviewer, NULL, NULL);
+  g_io_channel_set_encoding (in_from_appletviewer, NULL, &channel_error);
 
   if (!in_from_appletviewer)
     {

--- a/plugin/icedteanp/IcedTeaNPPlugin.cc
+++ b/plugin/icedteanp/IcedTeaNPPlugin.cc
@@ -630,6 +630,9 @@ NPError start_jvm_if_needed()
   // in_from_appletviewer
   in_from_appletviewer = g_io_channel_new_file (in_pipe_name,
                                                       "r", &channel_error);
+  // Setting encoding to binary so plugin does not crash when reading line in plugin_in_pipe_callback() for newer GLib versions
+  g_io_channel_set_encoding (in_from_appletviewer, NULL, NULL);
+
   if (!in_from_appletviewer)
     {
       if (channel_error)


### PR DESCRIPTION
Due to my work stuff, I was trying to use IcedTea-Web browser plugin in firefox browser on Debian 12 to run some java applets.
When I built this plugin from source, the plugin was crashing as it tried to initialize. After some debugging, I found out that the plugin was crashing when it encountered null bytes in a UTF-8 encoded stream.
I think it was attempting to read from the appletviewer channel to check whether the JVM was running. Due to changes in the version of Glib used in Debian 12, the library no longer accepted null bytes in UTF-8 streams, which caused the plugin to crash when such bytes were present. At least that's what I understood from the research I did.

This update changes the encoding to NULL so it accepts all data.

I know this is legacy and probably only a handful of people still use the browser plugin, but I figured I’d share it in case someone wants to use it like I have to