### PR TITLE
Fix for building for Windows with Rust 1.87+ (1.8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
             sha256sum "$zip" > "$zip.sha256.txt"
           done
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: icedtea-web_build_x86-64_linux
           path: |
@@ -232,7 +232,7 @@ jobs:
             sha256sum "$zip_rename" > "$zip_rename.sha256.txt"
           done
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: icedtea-web_build_x86-64_portable
           path: |
@@ -308,7 +308,7 @@ jobs:
             sha256sum "$zip" > "$zip.sha256.txt"
           done
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: icedtea-web_build_x86-64_macos
           path: |
@@ -436,7 +436,7 @@ jobs:
         run: bash .github/workflows/windows_build.sh
         shell: cmd
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: icedtea-web_build_x86-64_win
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ on:
   pull_request:
     branches:
       - 1.8
-
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   release:
     if: github.event.inputs.release == 'True'
@@ -41,9 +37,9 @@ jobs:
     needs: release
     name: Linux
     runs-on: ubuntu-latest
-    container: centos:7
+    container: centos:8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: icedtea-web
 
@@ -55,7 +51,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          yum -y install autoconf bind-utils bzip2 cpio elfutils-libelf-devel gcc gcc-c++ glibc glibc-common glibc-devel \
+          yum -y install autoconf bind-utils bzip2 elfutils-libelf-devel gcc gcc-c++ glibc-devel \
           gmp-devel java-1.8.0-openjdk-devel libcurl-devel make mpfr-devel perl unzip which zip
           curl -o tagsoup.jar "https://repo1.maven.org/maven2/org/ccil/cowan/tagsoup/tagsoup/1.2.1/tagsoup-1.2.1.jar"
           sha256sum tagsoup.jar | awk '$1!="ac97f7b4b1d8e9337edfa0e34044f8d0efe7223f6ad8f3a85d54cc1018ea2e04"{exit 1}'
@@ -82,14 +78,14 @@ jobs:
 
       - name: Compile automake
         run: |
-          curl -o automake-1.13.1.tar.gz "https://ftp.gnu.org/gnu/automake/automake-1.13.1.tar.gz"
-          sha256sum automake-1.13.1.tar.gz | awk '$1!="51bc10031847e9965c4f2c16a0a66552309ce28ea82b1afa8cef736643ebaa27"{exit 1}'
-          tar -zxf automake-1.13.1.tar.gz 
-          cd automake-1.13.1
+          curl -o automake-1.15.1.tar.gz "https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz"
+          sha256sum automake-1.15.1.tar.gz | awk '$1!="988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260"{exit 1}'
+          tar -zxf automake-1.15.1.tar.gz 
+          cd automake-1.15.1
           bash configure
           make && make install
           rm -rf /usr/local/bin/automake
-          ln -s /usr/local/bin/automake-1.13 /usr/local/bin/automake
+          ln -s /usr/local/bin/automake-1.15 /usr/local/bin/automake
 
       - name: Build
         run: |
@@ -124,7 +120,7 @@ jobs:
             sha256sum "$zip" > "$zip.sha256.txt"
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: icedtea-web_build_x86-64_linux
           path: |
@@ -157,9 +153,9 @@ jobs:
     needs: release
     name: Portable
     runs-on: ubuntu-latest
-    container: centos:7
+    container: centos:8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: icedtea-web
 
@@ -171,7 +167,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          yum -y install autoconf bind-utils bzip2 cpio elfutils-libelf-devel gcc gcc-c++ glibc glibc-common glibc-devel \
+          yum -y install autoconf bind-utils bzip2 elfutils-libelf-devel gcc gcc-c++ glibc-devel \
           gmp-devel java-1.8.0-openjdk-devel libcurl-devel make mpfr-devel perl unzip which zip
           curl -o tagsoup.jar "https://repo1.maven.org/maven2/org/ccil/cowan/tagsoup/tagsoup/1.2.1/tagsoup-1.2.1.jar"
           sha256sum tagsoup.jar | awk '$1!="ac97f7b4b1d8e9337edfa0e34044f8d0efe7223f6ad8f3a85d54cc1018ea2e04"{exit 1}'
@@ -192,14 +188,14 @@ jobs:
 
       - name: Compile automake
         run: |
-          curl -o automake-1.13.1.tar.gz "https://ftp.gnu.org/gnu/automake/automake-1.13.1.tar.gz"
-          sha256sum automake-1.13.1.tar.gz | awk '$1!="51bc10031847e9965c4f2c16a0a66552309ce28ea82b1afa8cef736643ebaa27"{exit 1}'
-          tar -zxf automake-1.13.1.tar.gz 
-          cd automake-1.13.1
+          curl -o automake-1.15.1.tar.gz "https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz"
+          sha256sum automake-1.15.1.tar.gz | awk '$1!="988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260"{exit 1}'
+          tar -zxf automake-1.15.1.tar.gz 
+          cd automake-1.15.1
           bash configure
           make && make install
           rm -rf /usr/local/bin/automake
-          ln -s /usr/local/bin/automake-1.13 /usr/local/bin/automake
+          ln -s /usr/local/bin/automake-1.15 /usr/local/bin/automake
 
       - name: Build
         run: |
@@ -232,7 +228,7 @@ jobs:
             sha256sum "$zip_rename" > "$zip_rename.sha256.txt"
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: icedtea-web_build_x86-64_portable
           path: |
@@ -266,7 +262,7 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: icedtea-web
 
@@ -308,7 +304,7 @@ jobs:
             sha256sum "$zip" > "$zip.sha256.txt"
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: icedtea-web_build_x86-64_macos
           path: |
@@ -344,7 +340,7 @@ jobs:
     steps:
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: C:\cygwin_packages
           key: cygwin-packages-${{ runner.os }}-v1
@@ -377,7 +373,7 @@ jobs:
         shell: bash
         run: mkdir $HOME && git config --system core.autocrlf false && git config --system --add safe.directory '*'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           set-safe-directory: false
 
@@ -436,7 +432,7 @@ jobs:
         run: bash .github/workflows/windows_build.sh
         shell: cmd
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: icedtea-web_build_x86-64_win
           path: |

--- a/.github/workflows/windows_build.sh
+++ b/.github/workflows/windows_build.sh
@@ -5,7 +5,7 @@ export ICEDTEAWEB_INSTALL="$(cygpath -u "${WORKSPACE}/icedtea-web-image")"
 export WIXPATH="$(cygpath -u "C:/PROGRA~2/WIXTOO~1.14/bin")"
 export WIXGEN="$(cygpath -u "C:/cygwin64/usr/share/java/wixgen.jar")"
 export PATH="${PATH}:/cygdrive/c/rust/bin:${WIXPATH}"
-export JVM_HOME_SHORT="$(cygpath -d "${JAVA_HOME}")"
+export JVM_HOME_SHORT="$(cygpath -d "${JAVA_HOME_8_X64}")"
 export JVMPATH="$(cygpath -u ${JVM_HOME_SHORT})"
 echo "Configure IcedTea-Web"
 ./autogen.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,6 @@ if WINDOWS
 	export TOP_SRC_DIR := $(shell cygpath -p -m "$(abs_top_srcdir)")
 	export prefix := $(shell cygpath -p -m "$(prefix)")
 	export CPA="-v"
-	RUSTFLAGS="-C link-arg=-ladvapi32"
 else
 	export TOP_BUILD_DIR = $(abs_top_builddir)
 	export TOP_SRC_DIR = $(abs_top_srcdir)
@@ -1014,7 +1013,6 @@ launcher.build/$(javaws) launcher.build/$(itweb_settings) launcher.build/$(polic
 	  export RHINO_JAR=$(RHINO_JAR) ; \
 	  export MSLINKS_JAR=$(MSLINKS_JAR) ; \
 	  export MODULARJDK_ARGS_LOCATION=$(MODULARJDK_ARGS_LOCATION) ; \
-	  export RUSTFLAGS=${RUSTFLAGS} ; \
 	  unset MAIN_CLASS ; \
 	  unset BIN_LOCATION ; \
 	  unset PROGRAM_NAME ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ if WINDOWS
 	export TOP_SRC_DIR := $(shell cygpath -p -m "$(abs_top_srcdir)")
 	export prefix := $(shell cygpath -p -m "$(prefix)")
 	export CPA="-v"
+	RUSTFLAGS="-C link-arg=-ladvapi32"
 else
 	export TOP_BUILD_DIR = $(abs_top_builddir)
 	export TOP_SRC_DIR = $(abs_top_srcdir)
@@ -547,8 +548,8 @@ $(WIN_INSTALLER_DIR)/itw-installer.json: clean-win-installer
 
 win-installer: win-only-image $(WIN_INSTALLER_DIR)/itw-installer.json
 	"$(JAVA)" -jar "$(WIXGEN_JAR)" "$(DESTDIR)$(prefix)" -c $(WIN_INSTALLER_DIR)/itw-installer.json -o $(WIN_INSTALLER_DIR)/itw-installer.wxs
-	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/candle.exe /nologo itw-installer.wxs
-	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/light.exe /nologo -sval -ext WixUIExtension itw-installer.wixobj
+	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/candle.exe -nologo itw-installer.wxs
+	cd $(WIN_INSTALLER_DIR) && "$(WIX_TOOLSET_DIR)"/light.exe -nologo -sval -ext WixUIExtension itw-installer.wixobj
 	cd $(WIN_INSTALLER_DIR) && mv itw-installer.msi $(distdir).msi
 endif
 
@@ -1013,6 +1014,7 @@ launcher.build/$(javaws) launcher.build/$(itweb_settings) launcher.build/$(polic
 	  export RHINO_JAR=$(RHINO_JAR) ; \
 	  export MSLINKS_JAR=$(MSLINKS_JAR) ; \
 	  export MODULARJDK_ARGS_LOCATION=$(MODULARJDK_ARGS_LOCATION) ; \
+	  export RUSTFLAGS=${RUSTFLAGS} ; \
 	  unset MAIN_CLASS ; \
 	  unset BIN_LOCATION ; \
 	  unset PROGRAM_NAME ; \
@@ -1441,7 +1443,7 @@ netx-dist-tests-remove-cert-from-public:
 	keystoredir=`dirname $$PUBLIC_KEYSTORE`; \
 	[ ! -d $$keystoredir ] && mkdir -p $$keystoredir; \
 	for which in "$${types[@]}" ; do \
-	  $(SYSTEM_JDK_DIR)/bin/keytool -delete -alias $(TEST_CERT_ALIAS)_$$which -keystore $$PUBLIC_KEYSTORE -storepass $(PUBLIC_KEYSTORE_PASS) ; \
+	  $(SYSTEM_JDK_DIR)/bin/keytool -delete -alias $(TEST_CERT_ALIAS)_$$which -keystore $$PUBLIC_KEYSTORE -storepass $(PUBLIC_KEYSTORE_PASS); true; \
 	done ;
 	-rm -rf stamps/netx-dist-tests-import-cert-to-public
 

--- a/rust-launcher/src/os_access.rs
+++ b/rust-launcher/src/os_access.rs
@@ -396,6 +396,7 @@ pub mod win {
 
     // function declarations
 
+    #[link(name = "advapi32", kind = "dylib")]
     extern "system" {
         pub fn AttachConsole(dwProcessId: c_ulong) -> c_int;
         


### PR DESCRIPTION
BTW: Fix incorrect argument passing to candle.exe and light.exe and prevent make clean from aborting